### PR TITLE
feat(content): migrate About Me section to dynamic Markdown and enhance markdown editor

### DIFF
--- a/backend/alembic/versions/013_seed_about_me_markdown.py
+++ b/backend/alembic/versions/013_seed_about_me_markdown.py
@@ -1,0 +1,98 @@
+"""seed_about_me_markdown
+
+Revision ID: 7c1449a15449
+Revises: 012_remove_photo_fields
+Create Date: 2026-03-19 12:55:41.504690
+
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import uuid4
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "013_seed_about_me_markdown"
+down_revision = "012_remove_photo_fields"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Define the content table
+    content_table = sa.table(
+        "content",
+        sa.column("id", sa.UUID),
+        sa.column("key", sa.String),
+        sa.column("title", sa.String),
+        sa.column("content", sa.Text),
+        sa.column("content_type", sa.String),
+        sa.column("category", sa.String),
+        sa.column("is_active", sa.Boolean),
+        sa.column("created_at", sa.DateTime),
+        sa.column("updated_at", sa.DateTime),
+    )
+
+    # About Bio
+    op.bulk_insert(
+        content_table,
+        [
+            {
+                "id": str(uuid4()),
+                "key": "about.bio",
+                "title": "Biography",
+                "content": (
+                    "My name is Anton (Hào-chen) Lu, and I'm a M.Sc. student at KTH Royal Institute of Technology "
+                    "in Stockholm, Sweden. I'm currently enrolled in a five-year degree programme in Engineering "
+                    "Physics, pursuing a M.Sc. in Machine Learning with specialization in deep learning and "
+                    "computational linguistics.\n\n"
+                    "My biggest passion is learning new things, whether it be a new problem solving method, "
+                    "a new programming language, a new spoken language, or how to capture the perfect moment "
+                    "through photography."
+                ),
+                "content_type": "markdown",
+                "category": "about",
+                "is_active": True,
+                "created_at": datetime.now(),
+                "updated_at": datetime.now(),
+            },
+            {
+                "id": str(uuid4()),
+                "key": "about.interests",
+                "title": "Interests",
+                "content": (
+                    "* 📸 Photography\n* 🎮 Gaming\n* 💻 Programming\n* 🏊 Swimming"
+                ),
+                "content_type": "markdown",
+                "category": "about",
+                "is_active": True,
+                "created_at": datetime.now(),
+                "updated_at": datetime.now(),
+            },
+            {
+                "id": str(uuid4()),
+                "key": "about.skills",
+                "title": "Skills",
+                "content": (
+                    "* 🤖 Machine Learning\n"
+                    "* 📊 Data Science\n"
+                    "* 🌐 Web Development\n"
+                    "* 🎯 Deep Learning"
+                ),
+                "content_type": "markdown",
+                "category": "about",
+                "is_active": True,
+                "created_at": datetime.now(),
+                "updated_at": datetime.now(),
+            },
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DELETE FROM content WHERE key IN ('about.bio', 'about.interests', 'about.skills')"
+    )

--- a/backend/alembic/versions/014_seed_about_me_markdown.py
+++ b/backend/alembic/versions/014_seed_about_me_markdown.py
@@ -1,7 +1,7 @@
 """seed_about_me_markdown
 
-Revision ID: 7c1449a15449
-Revises: 012_remove_photo_fields
+Revision ID: 014_seed_about_me_markdown
+Revises: 013_oidc_auth
 Create Date: 2026-03-19 12:55:41.504690
 
 """
@@ -15,8 +15,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "013_seed_about_me_markdown"
-down_revision = "012_remove_photo_fields"
+revision = "014_seed_about_me_markdown"
+down_revision = "013_oidc_auth"
 branch_labels = None
 depends_on = None
 

--- a/frontend/src/components/admin/ContentEditor.tsx
+++ b/frontend/src/components/admin/ContentEditor.tsx
@@ -13,9 +13,6 @@ import { Textarea } from "../ui/textarea";
 import { Button } from "../ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import MDEditor from "@uiw/react-md-editor";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeHighlight from "rehype-highlight";
 
 type EditorMode = "text" | "html" | "markdown";
 
@@ -98,7 +95,7 @@ export const ContentEditor: React.FC<ContentEditorProps> = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[600px]">
+      <DialogContent className="sm:max-w-[1000px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
             {isEditing ? "Edit Content" : "Create Content"}
@@ -182,30 +179,21 @@ export const ContentEditor: React.FC<ContentEditorProps> = ({
           )}
 
           {contentType === "markdown" && (
-            <Tabs defaultValue="edit">
-              <TabsList>
-                <TabsTrigger value="edit">Edit</TabsTrigger>
-                <TabsTrigger value="preview">Preview</TabsTrigger>
-              </TabsList>
-              <TabsContent value="edit">
+            <div className="space-y-2">
+              <Label htmlFor="markdown-editor">Content (Markdown)</Label>
+              <div
+                data-color-mode="light"
+                className="border rounded-md overflow-hidden"
+              >
                 <MDEditor
+                  id="markdown-editor"
                   value={content}
                   onChange={(v) => setContent(v ?? "")}
-                  height={320}
-                  preview="edit"
+                  height={500}
+                  preview="live"
                 />
-              </TabsContent>
-              <TabsContent value="preview">
-                <div className="prose dark:prose-invert max-w-none">
-                  <ReactMarkdown
-                    remarkPlugins={[remarkGfm]}
-                    rehypePlugins={[rehypeHighlight]}
-                  >
-                    {content}
-                  </ReactMarkdown>
-                </div>
-              </TabsContent>
-            </Tabs>
+              </div>
+            </div>
           )}
 
           <DialogFooter className="pt-4">

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -9,6 +9,7 @@ import { formatDate } from "../utils/dateFormat";
 import { selectOptimalImage, ImageUseCase } from "../utils/imageUtils";
 import ProgressiveImage from "../components/ProgressiveImage";
 import ProfilePictureDisplay from "../components/ProfilePictureDisplay";
+import MarkdownRenderer from "../components/MarkdownRenderer";
 
 const HomePage: React.FC = () => {
   const { data: latestPhotos } = useQuery({
@@ -41,6 +42,9 @@ const HomePage: React.FC = () => {
         "social.linkedin_url",
         "social.google_scholar_url",
         "social.github_url",
+        "about.bio",
+        "about.interests",
+        "about.skills",
       ]),
     staleTime: 1000 * 60 * 5, // 5 minutes
   });
@@ -275,21 +279,14 @@ const HomePage: React.FC = () => {
               viewport={{ once: true }}
               className="space-y-6"
             >
-              <div className="prose prose-lg">
-                <p className="text-gray-700 leading-relaxed">
-                  My name is Anton (Hào-chen) Lu, and I'm a M.Sc. student at KTH
-                  Royal Institute of Technology in Stockholm, Sweden. I'm
-                  currently enrolled in a five-year degree programme in
-                  Engineering Physics, pursuing a M.Sc. in Machine Learning with
-                  specialization in deep learning and computational linguistics.
-                </p>
-                <p className="text-gray-700 leading-relaxed">
-                  My biggest passion is learning new things, whether it be a new
-                  problem solving method, a new programming language, a new
-                  spoken language, or how to capture the perfect moment through
-                  photography.
-                </p>
-              </div>
+              <MarkdownRenderer
+                content={
+                  homeContent?.["about.bio"]?.content ??
+                  `My name is Anton (Hào-chen) Lu, and I'm a M.Sc. student at KTH Royal Institute of Technology in Stockholm, Sweden. I'm currently enrolled in a five-year degree programme in Engineering Physics, pursuing a M.Sc. in Machine Learning with specialization in deep learning and computational linguistics.
+
+My biggest passion is learning new things, whether it be a new problem solving method, a new programming language, a new spoken language, or how to capture the perfect moment through photography.`
+                }
+              />
 
               <div className="grid grid-cols-2 gap-6">
                 <div className="bg-white p-6 rounded-lg shadow-sm">
@@ -297,23 +294,25 @@ const HomePage: React.FC = () => {
                     {homeContent?.["about.interests_title"]?.content ??
                       "Interests"}
                   </h3>
-                  <ul className="space-y-2 text-gray-700">
-                    <li>📸 Photography</li>
-                    <li>🎮 Gaming</li>
-                    <li>💻 Programming</li>
-                    <li>🏊 Swimming</li>
-                  </ul>
+                  <MarkdownRenderer
+                    content={
+                      homeContent?.["about.interests"]?.content ??
+                      "* 📸 Photography\n* 🎮 Gaming\n* 💻 Programming\n* 🏊 Swimming"
+                    }
+                    compact
+                  />
                 </div>
                 <div className="bg-white p-6 rounded-lg shadow-sm">
                   <h3 className="font-semibold text-gray-900 mb-3">
                     {homeContent?.["about.skills_title"]?.content ?? "Skills"}
                   </h3>
-                  <ul className="space-y-2 text-gray-700">
-                    <li>🤖 Machine Learning</li>
-                    <li>📊 Data Science</li>
-                    <li>🌐 Web Development</li>
-                    <li>🎯 Deep Learning</li>
-                  </ul>
+                  <MarkdownRenderer
+                    content={
+                      homeContent?.["about.skills"]?.content ??
+                      "* 🤖 Machine Learning\n* 📊 Data Science\n* 🌐 Web Development\n* 🎯 Deep Learning"
+                    }
+                    compact
+                  />
                 </div>
               </div>
             </motion.div>


### PR DESCRIPTION
Migrate the "About Me" section to dynamic Markdown, improve the admin content editor, and renumber the seed migration to 014 with an explicit dependency on 013_oidc_auth