### PR TITLE
Add PolyForm Noncommercial license and metadata

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,21 +1,12 @@
-MIT License
+PolyForm Noncommercial License 1.0.0
 
 Copyright (c) 2026 Haochen Lu
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This repository is licensed under the PolyForm Noncommercial License 1.0.0.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Use of the licensed material is permitted for noncommercial purposes only. For
+the full terms and conditions, see the official text at:
+https://polyformproject.org/licenses/noncommercial/1.0.0/
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+If you need a commercial license or have questions about licensing, contact
+the copyright holder at anton@haochen.lu.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Haochen Lu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -135,4 +135,5 @@ For TrueNAS Scale deployment, see [docs/TRUENAS_DEPLOYMENT.md](./docs/TRUENAS_DE
 
 ## License
 
-This project is released under the MIT License. See `LICENSE.md` for details.
+This project is licensed under the PolyForm Noncommercial License 1.0.0. See
+`LICENSE.md` for the full text and terms.

--- a/README.md
+++ b/README.md
@@ -132,3 +132,7 @@ docker compose up -d
 ```
 
 For TrueNAS Scale deployment, see [docs/TRUENAS_DEPLOYMENT.md](./docs/TRUENAS_DEPLOYMENT.md).
+
+## License
+
+This project is released under the MIT License. See `LICENSE.md` for details.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,6 +7,7 @@ name = "photography-portfolio"
 dynamic = ["version", "readme"]
 description = "Modern photography portfolio with FastAPI backend"
 requires-python = ">=3.11"
+license = { file = "LICENSE.md" }
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
@@ -14,6 +15,7 @@ classifiers = [
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.11",
+  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.11",
-  "License :: OSI Approved :: MIT License",
+  "License :: Other/Proprietary License",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "portfolio-frontend",
   "private": true,
+  "license": "MIT",
   "version": "0.0.0",
   "type": "module",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "portfolio-frontend",
   "private": true,
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
This PR updates the project license to PolyForm Noncommercial 1.0.0, replaces LICENSE.md with the PolyForm noncommercial text (link to official terms), updates README, and adds license metadata to backend/pyproject.toml and frontend/package.json.

Files changed:
- LICENSE.md
- README.md
- backend/pyproject.toml
- frontend/package.json

Notes:
- Frontend `package.json` now uses the SPDX-like identifier `PolyForm-Noncommercial-1.0.0`.
- Backend `pyproject.toml` references `LICENSE.md` via `license = { file = "LICENSE.md" }`.