### PR TITLE
fix(admin/applications): redesign, drag-to-reorder, credential security, nav fixes

### DIFF
--- a/backend/alembic/versions/015_remove_show_in_menu.py
+++ b/backend/alembic/versions/015_remove_show_in_menu.py
@@ -1,0 +1,28 @@
+"""remove show_in_menu from subapps
+
+Revision ID: 015_remove_show_in_menu
+Revises: 014_seed_about_me_markdown
+Create Date: 2026-03-29
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "015_remove_show_in_menu"
+down_revision = "014_seed_about_me_markdown"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("subapps", "show_in_menu")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "subapps",
+        sa.Column("show_in_menu", sa.Boolean(), nullable=False, server_default="true"),
+    )

--- a/backend/alembic/versions/016_add_logged_in_only.py
+++ b/backend/alembic/versions/016_add_logged_in_only.py
@@ -1,0 +1,33 @@
+"""add logged_in_only to subapps
+
+Revision ID: 016_add_logged_in_only
+Revises: 015_remove_show_in_menu
+Create Date: 2026-03-29
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "016_add_logged_in_only"
+down_revision = "015_remove_show_in_menu"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "subapps",
+        sa.Column(
+            "logged_in_only",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("subapps", "logged_in_only")

--- a/backend/app/api/applications.py
+++ b/backend/app/api/applications.py
@@ -42,13 +42,9 @@ async def list_applications(
     """List available applications for public access."""
     applications = await get_applications(db, enabled_only=True, admin_only=False)
 
-    public_applications = [app for app in applications if not app.requires_auth]
-
     return ApplicationListResponse(
-        applications=[
-            ApplicationResponse.model_validate(app) for app in public_applications
-        ],
-        total=len(public_applications),
+        applications=[ApplicationResponse.model_validate(app) for app in applications],
+        total=len(applications),
     )
 
 

--- a/backend/app/api/applications.py
+++ b/backend/app/api/applications.py
@@ -37,12 +37,10 @@ router = APIRouter()
 
 @router.get("/")
 async def list_applications(
-    *, menu_only: bool = True, db: AsyncSession = _session_dependency
+    *, db: AsyncSession = _session_dependency
 ) -> ApplicationListResponse:
     """List available applications for public access."""
-    applications = await get_applications(
-        db, enabled_only=True, menu_only=menu_only, admin_only=False
-    )
+    applications = await get_applications(db, enabled_only=True, admin_only=False)
 
     public_applications = [app for app in applications if not app.requires_auth]
 
@@ -57,16 +55,13 @@ async def list_applications(
 @router.get("/authenticated")
 async def list_authenticated_applications(
     *,
-    menu_only: bool = True,
     db: AsyncSession = _session_dependency,
     current_user: User = _current_user_dependency,
 ) -> ApplicationListResponse:
     """List applications available to authenticated users."""
     admin_only = None if current_user.is_admin else False
 
-    applications = await get_applications(
-        db, enabled_only=True, menu_only=menu_only, admin_only=admin_only
-    )
+    applications = await get_applications(db, enabled_only=True, admin_only=admin_only)
 
     return ApplicationListResponse(
         applications=[ApplicationResponse.model_validate(app) for app in applications],
@@ -77,14 +72,11 @@ async def list_authenticated_applications(
 @router.get("/admin")
 async def list_all_applications(
     *,
-    menu_only: bool = False,
     db: AsyncSession = _session_dependency,
     current_user: User = _current_admin_user_dependency,
 ) -> ApplicationListResponse:
     """List all applications (admin only)."""
-    applications = await get_applications(
-        db, enabled_only=False, menu_only=menu_only, admin_only=None
-    )
+    applications = await get_applications(db, enabled_only=False, admin_only=None)
 
     return ApplicationListResponse(
         applications=[ApplicationResponse.model_validate(app) for app in applications],
@@ -210,7 +202,6 @@ async def export_application(
             "is_external": application.is_external,
             "requires_auth": application.requires_auth,
             "admin_only": application.admin_only,
-            "show_in_menu": application.show_in_menu,
             "menu_order": application.order,
             "has_admin": bool(application.admin_url),
         },
@@ -242,9 +233,7 @@ async def get_application_stats(
 ) -> dict[str, int]:
     """Get application statistics (admin only)."""
     total_applications = await get_application_count(db)
-    enabled_applications = len(
-        await get_applications(db, enabled_only=True, menu_only=False)
-    )
+    enabled_applications = len(await get_applications(db, enabled_only=True))
 
     return {
         "total_applications": total_applications,

--- a/backend/app/api/applications.py
+++ b/backend/app/api/applications.py
@@ -8,6 +8,7 @@ from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.crud.application import (
+    bulk_reorder_applications,
     create_application,
     delete_application,
     get_application,
@@ -25,6 +26,7 @@ from app.models.user import User
 from app.schemas.application import (
     ApplicationCreate,
     ApplicationListResponse,
+    ApplicationReorderRequest,
     ApplicationResponse,
     ApplicationUpdate,
 )
@@ -137,6 +139,20 @@ async def update_application_endpoint(
         raise HTTPException(status_code=404, detail="Application not found")
 
     return ApplicationResponse.model_validate(application)
+
+
+@router.post("/reorder")
+async def reorder_applications(
+    payload: ApplicationReorderRequest,
+    db: AsyncSession = _session_dependency,
+    current_user: User = _current_admin_user_dependency,
+) -> dict[str, str]:
+    """Bulk reorder applications (admin only)."""
+    items: list[dict[str, str | int]] = [
+        {"id": str(i.id), "order": i.order} for i in payload.items
+    ]
+    await bulk_reorder_applications(db, items, normalize=payload.normalize)
+    return {"message": "Reordered successfully"}
 
 
 @router.delete("/{application_id}")

--- a/backend/app/api/applications.py
+++ b/backend/app/api/applications.py
@@ -27,6 +27,8 @@ from app.models.user import User
 from app.schemas.application import (
     ApplicationCreate,
     ApplicationListResponse,
+    ApplicationPublicListResponse,
+    ApplicationPublicResponse,
     ApplicationReorderRequest,
     ApplicationResponse,
     ApplicationUpdate,
@@ -38,12 +40,14 @@ router = APIRouter()
 @router.get("/")
 async def list_applications(
     *, db: AsyncSession = _session_dependency
-) -> ApplicationListResponse:
+) -> ApplicationPublicListResponse:
     """List available applications for public access."""
     applications = await get_applications(db, enabled_only=True, admin_only=False)
 
-    return ApplicationListResponse(
-        applications=[ApplicationResponse.model_validate(app) for app in applications],
+    return ApplicationPublicListResponse(
+        applications=[
+            ApplicationPublicResponse.model_validate(app) for app in applications
+        ],
         total=len(applications),
     )
 
@@ -53,14 +57,16 @@ async def list_authenticated_applications(
     *,
     db: AsyncSession = _session_dependency,
     current_user: User = _current_user_dependency,
-) -> ApplicationListResponse:
+) -> ApplicationPublicListResponse:
     """List applications available to authenticated users."""
     admin_only = None if current_user.is_admin else False
 
     applications = await get_applications(db, enabled_only=True, admin_only=admin_only)
 
-    return ApplicationListResponse(
-        applications=[ApplicationResponse.model_validate(app) for app in applications],
+    return ApplicationPublicListResponse(
+        applications=[
+            ApplicationPublicResponse.model_validate(app) for app in applications
+        ],
         total=len(applications),
     )
 

--- a/backend/app/api/applications.py
+++ b/backend/app/api/applications.py
@@ -15,6 +15,7 @@ from app.crud.application import (
     get_application_by_slug,
     get_application_count,
     get_applications,
+    regenerate_application_credentials,
     update_application,
 )
 from app.dependencies import (
@@ -138,6 +139,19 @@ async def update_application_endpoint(
     if not application:
         raise HTTPException(status_code=404, detail="Application not found")
 
+    return ApplicationResponse.model_validate(application)
+
+
+@router.post("/{application_id}/regenerate-credentials")
+async def regenerate_credentials(
+    application_id: UUID,
+    db: AsyncSession = _session_dependency,
+    current_user: User = _current_admin_user_dependency,
+) -> ApplicationResponse:
+    """Regenerate client ID and secret for an application (admin only)."""
+    application = await regenerate_application_credentials(db, application_id)
+    if not application:
+        raise HTTPException(status_code=404, detail="Application not found")
     return ApplicationResponse.model_validate(application)
 
 

--- a/backend/app/crud/application.py
+++ b/backend/app/crud/application.py
@@ -129,6 +129,21 @@ async def update_application(
     return db_app
 
 
+async def regenerate_application_credentials(
+    db: AsyncSession, application_id: UUID
+) -> Application | None:
+    result = await db.execute(
+        select(Application).where(Application.id == application_id)
+    )
+    db_app = result.scalar_one_or_none()
+    if db_app:
+        db_app.client_id = secrets.token_urlsafe(16)
+        db_app.client_secret = secrets.token_urlsafe(32)
+        await db.commit()
+        await db.refresh(db_app)
+    return db_app
+
+
 async def bulk_reorder_applications(
     db: AsyncSession,
     items: list[dict[str, str | int]],

--- a/backend/app/crud/application.py
+++ b/backend/app/crud/application.py
@@ -66,6 +66,12 @@ async def get_application_by_client_id(
     return result.scalar_one_or_none()
 
 
+async def _next_order(db: AsyncSession) -> int:
+    result = await db.execute(select(func.max(Application.order)))
+    current_max = result.scalar()
+    return (current_max or 0) + 1
+
+
 async def create_application(db: AsyncSession, app: ApplicationCreate) -> Application:
     slug = app.slug or generate_slug(app.name)
 
@@ -78,6 +84,7 @@ async def create_application(db: AsyncSession, app: ApplicationCreate) -> Applic
 
     app_data = app.model_dump()
     app_data["slug"] = slug
+    app_data["order"] = await _next_order(db)
     if app_data.get("requires_auth"):
         if not app_data.get("client_id"):
             app_data["client_id"] = secrets.token_urlsafe(16)

--- a/backend/app/crud/application.py
+++ b/backend/app/crud/application.py
@@ -83,9 +83,12 @@ async def create_application(db: AsyncSession, app: ApplicationCreate) -> Applic
     app_data = app.model_dump()
     app_data["slug"] = slug
     if app_data.get("requires_auth"):
-        app_data.setdefault("client_id", secrets.token_urlsafe(16))
-        app_data.setdefault("client_secret", secrets.token_urlsafe(32))
-        app_data.setdefault("redirect_uris", default_redirect_uri(str(app_data["url"])))
+        if not app_data.get("client_id"):
+            app_data["client_id"] = secrets.token_urlsafe(16)
+        if not app_data.get("client_secret"):
+            app_data["client_secret"] = secrets.token_urlsafe(32)
+        if not app_data.get("redirect_uris"):
+            app_data["redirect_uris"] = default_redirect_uri(str(app_data["url"]))
 
     db_app = Application(**app_data)
     db.add(db_app)
@@ -124,6 +127,27 @@ async def update_application(
         await db.refresh(db_app)
 
     return db_app
+
+
+async def bulk_reorder_applications(
+    db: AsyncSession,
+    items: list[dict[str, str | int]],
+    *,
+    normalize: bool = False,
+) -> None:
+    pairs: list[tuple[UUID, int]] = [
+        (UUID(str(it["id"])), int(it["order"])) for it in items
+    ]
+    if normalize:
+        pairs = [
+            (pid, idx) for idx, (pid, _) in enumerate(sorted(pairs, key=lambda x: x[1]))
+        ]
+    for app_id, order in pairs:
+        result = await db.execute(select(Application).where(Application.id == app_id))
+        db_app = result.scalar_one_or_none()
+        if db_app:
+            db_app.order = order
+    await db.commit()
 
 
 async def delete_application(db: AsyncSession, application_id: UUID) -> bool:

--- a/backend/app/crud/application.py
+++ b/backend/app/crud/application.py
@@ -23,16 +23,12 @@ async def get_applications(
     db: AsyncSession,
     *,
     enabled_only: bool = True,
-    menu_only: bool = True,
     admin_only: bool | None = None,
 ) -> list[Application]:
     query = select(Application)
 
     if enabled_only:
         query = query.where(Application.enabled)
-
-    if menu_only:
-        query = query.where(Application.show_in_menu)
 
     if admin_only is not None:
         query = query.where(Application.admin_only == admin_only)

--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -38,7 +38,6 @@ class Application(Base):
 
     order: Mapped[int] = mapped_column(Integer, default=0)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True)
-    show_in_menu: Mapped[bool] = mapped_column(Boolean, default=True)
 
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(

--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -36,6 +36,7 @@ class Application(Base):
     client_secret: Mapped[str | None] = mapped_column(String(100), nullable=True)
     redirect_uris: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    logged_in_only: Mapped[bool] = mapped_column(Boolean, default=False)
     order: Mapped[int] = mapped_column(Integer, default=0)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True)
 

--- a/backend/app/schemas/app_config.py
+++ b/backend/app/schemas/app_config.py
@@ -34,7 +34,6 @@ class AppIntegration(BaseModel):
 
     requires_auth: bool = Field(default=True, description="Requires authentication")
     admin_only: bool = Field(default=False, description="Admin-only access")
-    show_in_menu: bool = Field(default=True, description="Show in navigation menu")
     menu_order: int = Field(default=10, description="Menu ordering", ge=0, le=100)
 
     has_admin: bool = Field(default=False, description="Has admin interface")

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -28,7 +28,6 @@ class ApplicationBase(BaseModel):
     admin_only: bool = False
     logged_in_only: bool = False
     enabled: bool = True
-    order: int = 0
     client_id: str | None = None
     client_secret: str | None = None
     redirect_uris: str | None = None
@@ -50,7 +49,6 @@ class ApplicationUpdate(BaseModel):
     client_secret: str | None = None
     redirect_uris: str | None = None
     enabled: bool | None = None
-    order: int | None = None
 
 
 class ApplicationResponse(ApplicationBase):

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -62,6 +62,34 @@ class ApplicationResponse(ApplicationBase):
     updated_at: datetime
 
 
+class ApplicationPublicResponse(BaseModel):
+    """Response schema for public/authenticated endpoints — omits credentials."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    slug: str
+    name: str
+    description: str | None = None
+    icon: str | None = None
+    color: str | None = None
+    url: str
+    admin_url: str | None = None
+    is_external: bool
+    requires_auth: bool
+    admin_only: bool
+    logged_in_only: bool
+    enabled: bool
+    order: int
+    created_at: datetime
+    updated_at: datetime
+
+
 class ApplicationListResponse(BaseModel):
     applications: list[ApplicationResponse]
+    total: int
+
+
+class ApplicationPublicListResponse(BaseModel):
+    applications: list[ApplicationPublicResponse]
     total: int

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -26,7 +26,6 @@ class ApplicationBase(BaseModel):
     is_external: bool = False
     requires_auth: bool = True
     admin_only: bool = False
-    show_in_menu: bool = True
     enabled: bool = True
     order: int = 0
     client_id: str | None = None
@@ -49,7 +48,6 @@ class ApplicationUpdate(BaseModel):
     client_secret: str | None = None
     redirect_uris: str | None = None
     enabled: bool | None = None
-    show_in_menu: bool | None = None
     order: int | None = None
 
 

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -26,6 +26,7 @@ class ApplicationBase(BaseModel):
     is_external: bool = False
     requires_auth: bool = True
     admin_only: bool = False
+    logged_in_only: bool = False
     enabled: bool = True
     order: int = 0
     client_id: str | None = None
@@ -44,6 +45,7 @@ class ApplicationUpdate(BaseModel):
     admin_url: str | None = None
     requires_auth: bool | None = None
     admin_only: bool | None = None
+    logged_in_only: bool | None = None
     client_id: str | None = None
     client_secret: str | None = None
     redirect_uris: str | None = None

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
 from datetime import datetime
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
+
+
+class ApplicationReorderItem(BaseModel):
+    id: str | UUID
+    order: int
+
+
+class ApplicationReorderRequest(BaseModel):
+    items: list[ApplicationReorderItem]
+    normalize: bool = False
 
 
 class ApplicationBase(BaseModel):
@@ -45,7 +56,7 @@ class ApplicationUpdate(BaseModel):
 class ApplicationResponse(ApplicationBase):
     model_config = ConfigDict(from_attributes=True)
 
-    id: str
+    id: UUID
     slug: str
     created_at: datetime
     updated_at: datetime

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -231,9 +231,7 @@ class SubAppFactory(AsyncSQLAlchemyModelFactory):
     client_id = factory.LazyFunction(lambda: secrets.token_urlsafe(12))
     client_secret = factory.LazyFunction(lambda: secrets.token_urlsafe(24))
     redirect_uris = LazyAttribute(lambda obj: f"{obj.url}/callback")
-    show_in_menu = True
     enabled = True
-    order = Faker("random_int", min=0, max=100)
 
     created_at = Faker("date_time_this_year")
     updated_at = LazyAttribute(lambda obj: obj.created_at)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -153,6 +153,7 @@ services:
       - ./authelia/assets:/assets:ro
     networks:
       - portfolio-network
+      - first-party-auth-network
     ports:
       - "9091:9091"
 

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -4,113 +4,167 @@
 
 ## Main pieces
 
-- Authelia handles the user login.
+- Authelia handles user login.
 - `haochen.lu` syncs the OIDC user into its local `users` table.
 - `haochen.lu` issues short-lived auth codes and access tokens for registered
   first-party apps.
-- Sub-apps exchange codes through their own backend using `client_secret`.
-- Sub-apps validate access tokens by calling `haochen.lu /api/auth/me`.
+- Apps exchange codes through their own backend using `client_secret`.
+- Apps validate access tokens by calling `haochen.lu /api/auth/me`.
 
-## 🔐 The "Hub and Spoke" Model
+## The "Hub and Spoke" Model
 
-It's important to differentiate between the two types of credentials:
+Two distinct credential relationships:
 
-1.  **Broker -> Authelia (The "Hub")**:
-    - This is the single connection between `haochen.lu` and Authelia.
-    - You only need **one** set of `OIDC_CLIENT_ID/SECRET` for the entire platform.
-    - All sub-apps inherit this connection. You **do not** need to register every individual sub-app in Authelia.
+1. **Broker → Authelia (the hub)**
+   - One set of `OIDC_CLIENT_ID/SECRET` for the entire platform.
+   - All apps inherit this connection — you do not register each app in Authelia.
 
-2.  **Sub-app -> Broker (The "Spokes")**:
-    - Each sub-app (e.g., `moviedb-manager`) gets its own `client_id` and `client_secret` **from `haochen.lu`**.
-    - These are used to authenticate the sub-app with the `haochen.lu` broker.
-    - `haochen.lu` manages these internally in its sub-app registry.
+2. **App → Broker (the spokes)**
+   - Each app gets its own `client_id` and `client_secret` from `haochen.lu`.
+   - Managed via the admin interface at `/admin/applications`.
 
-## Sub-app registration
+## Registering an app
 
-Each sub-app in the registry can define:
+Each app in the registry defines:
 
-- `url`: main app URL
-- `admin_url`: optional admin destination
-- `client_id`
-- `client_secret`
-- `redirect_uris`
+| Field | Required | Description |
+|---|---|---|
+| `url` | yes | Main app URL |
+| `admin_url` | no | Optional admin destination |
+| `requires_auth` | yes | Enables OIDC flow and auto-generates credentials |
+| `client_id` | auto | Generated on creation if `requires_auth` is true |
+| `client_secret` | auto | Generated on creation if `requires_auth` is true |
+| `redirect_uris` | auto | Defaults to `{url}/auth/callback` |
 
-If `requires_auth` is enabled and credentials are missing, `haochen.lu` creates
-them automatically. The default redirect URI is:
-
-```text
-{subapp.url}/auth/callback
-```
-
-Override `redirect_uris` if the callback lives somewhere else.
+Override `redirect_uris` if the callback lives somewhere else. The field accepts
+a comma- or newline-separated list, or a JSON array of strings.
 
 ## Browser flow
 
-1. A sub-app redirects the browser to:
+### 1. App initiates login
 
-```text
-/login?client_id=...&redirect_uri=...&response_type=code&state=...
+Redirect the browser to:
+
+```
+GET /api/auth/login?client_id=...&redirect_uri=...&response_type=code&state=...
 ```
 
-2. `haochen.lu` sends the user to Authelia.
-3. Authelia sends the browser back to `haochen.lu /api/auth/callback`.
-4. `haochen.lu` creates a local session and redirects to the sub-app callback:
+| Parameter | Required | Description |
+|---|---|---|
+| `client_id` | yes | Your app's `client_id` from the registry |
+| `redirect_uri` | yes | Must exactly match one of the registered `redirect_uris` |
+| `response_type` | yes | Must be `code` |
+| `state` | yes | Opaque string you generate; returned unchanged in the callback |
 
-```text
+`haochen.lu` validates the parameters and forwards the user to Authelia.
+
+### 2. Authelia authenticates the user
+
+The user logs in with their Authelia credentials. On success, Authelia redirects
+back to `haochen.lu /api/auth/callback`.
+
+### 3. Broker redirects to your app
+
+`haochen.lu` creates a local session, then redirects to your `redirect_uri`:
+
+```
 {redirect_uri}?code=...&state=...
 ```
 
-5. The sub-app backend exchanges the code at:
+The `code` is a short-lived single-use authorization code (~60 seconds).
+The `state` is the value you passed in step 1 — verify it matches to prevent CSRF.
 
-```text
+### 4. Exchange the code for a token
+
+Your **backend** (never the browser) calls:
+
+```
 POST /api/auth/oauth/token
+Content-Type: application/json
+
+{
+  "grant_type": "authorization_code",
+  "code": "<code from callback>",
+  "client_id": "<your client_id>",
+  "client_secret": "<your client_secret>",
+  "redirect_uri": "<same redirect_uri used in step 1>"
+}
 ```
 
-6. The sub-app stores the access token on its own domain.
+Response `200 OK`:
 
-## Admin jump
-
-For authenticated admins, `haochen.lu` exposes:
-
-```text
-GET /api/auth/jump/{slug}?target=app
-GET /api/auth/jump/{slug}?target=admin
+```json
+{
+  "access_token": "<JWT>",
+  "token_type": "bearer",
+  "expires_in": 900,
+  "user": {
+    "id": "<uuid>",
+    "email": "user@example.com",
+    "username": "anton",
+    "is_admin": true,
+    "oidc_id": "<authelia subject>",
+    "created_at": "...",
+    "updated_at": "..."
+  }
+}
 ```
 
-The admin UI uses this to jump into either the main sub-app entrypoint or the
-registered `admin_url`.
+`expires_in` is in seconds (default: 900 = 15 minutes). Store the token on your
+own domain (e.g. an httpOnly cookie or server-side session).
 
-## Required env
+Error responses follow standard OAuth error codes:
+- `400 unsupported_grant_type` — `grant_type` is not `authorization_code`
+- `401 invalid_client` — `client_id`/`client_secret` mismatch
+- `400 invalid_grant` — code expired, already used, or parameters don't match
 
-`haochen.lu`:
+### 5. Validate the token on subsequent requests
 
-- `OIDC_ENDPOINT`
-- `OIDC_CLIENT_ID`
-- `OIDC_CLIENT_SECRET`
-- `OIDC_REDIRECT_URI`
-- `SECRET_KEY`
-- `SESSION_SECRET_KEY`
+Your backend passes the token to `haochen.lu` to verify it and get the current
+user:
 
-First-party sub-apps:
+```
+GET /api/auth/me
+Authorization: Bearer <access_token>
+```
 
-- broker base URL
-- `client_id`
-- `client_secret`
-- broker callback `redirect_uri`
+Response `200 OK`: same `UserRead` object as in the token exchange response.
+
+- `401 Unauthorized` — token missing, expired, or invalid.
+
+Call this on every protected request, or cache the result for the token's
+remaining lifetime.
+
+## Required env vars
+
+### `haochen.lu` broker
+
+- `OIDC_ENDPOINT` — Authelia base URL
+- `OIDC_CLIENT_ID` — broker's Authelia client ID
+- `OIDC_CLIENT_SECRET` — broker's Authelia client secret
+- `OIDC_REDIRECT_URI` — broker's Authelia callback URL
+- `SECRET_KEY` — JWT signing key
+- `SESSION_SECRET_KEY` — session encryption key
+
+### Each app
+
+- `AUTH_BASE_URL` — broker base URL (e.g. `https://haochen.lu` or `http://auth-broker:8000` in Docker)
+- `CLIENT_ID` — your app's `client_id` from the registry
+- `CLIENT_SECRET` — your app's `client_secret` from the registry
+- `REDIRECT_URI` — your callback URL (must match registry)
 
 ## Local Docker setup
 
-The development compose files use a shared Docker network named
-`first-party-auth-network`.
+Dev compose files use a shared Docker network named `first-party-auth-network`.
 
-- `haochen.lu` backend joins this network with alias `auth-broker`
-- first-party sub-app backends join the same network
-- sub-app backends should call the broker at `http://auth-broker:8000`
-- browser redirects still use `http://localhost/login`
+- `haochen.lu` backend joins this network as `auth-broker`
+- App backends join the same network
+- App backends call the broker at `http://auth-broker:8000`
+- Browser redirects use `http://localhost`
 
-For `moviedb-manager` in local Docker:
+Example for `moviedb-manager`:
 
-```text
+```
 MOVIEDB_SECURITY__AUTH_BASE_URL=http://auth-broker:8000
 MOVIEDB_SECURITY__REDIRECT_URI=http://localhost:6001/auth/callback
 VITE_AUTH_BASE_URL=http://localhost
@@ -121,18 +175,17 @@ VITE_AUTH_REDIRECT_URI=http://localhost:6001/auth/callback
 
 Authelia users are defined in `authelia/config/users_database.yml`.
 
-| username | password   |
-|----------|------------|
-| admin    | adminadmin |
-| root     | adminadmin |
+| username | password |
+|---|---|
+| admin | adminadmin |
+| root | adminadmin |
 
 Both are in the `admins` group.
 
-## Deploying Authelia behind a reverse proxy
+## Deploying behind a reverse proxy
 
-Authelia requires `authelia_url` to use `https://`. In production this is fine — your outer nginx terminates TLS and users hit Authelia over HTTPS.
-
-For this to work correctly, the reverse proxy must forward these headers to Authelia:
+Authelia requires `https://`. Your outer nginx terminates TLS; forward these
+headers to Authelia:
 
 ```nginx
 proxy_set_header X-Forwarded-Proto https;
@@ -140,11 +193,15 @@ proxy_set_header X-Forwarded-Host $host;
 proxy_set_header X-Forwarded-Port 443;
 ```
 
-Without `X-Forwarded-Proto: https`, Authelia may reject or misbehave even if the user connected over TLS.
+Without `X-Forwarded-Proto: https`, Authelia may reject requests even if the
+user connected over TLS.
 
-In development, a self-signed cert is used for `localhost.localdomain` so the same nginx-terminates-TLS pattern is preserved locally. `./dev.sh start` generates this cert automatically in `authelia/certs/` if it doesn't exist (the directory is gitignored).
+In development, a self-signed cert is used for `localhost.localdomain` to
+preserve the same TLS pattern locally. `./dev.sh start` generates this cert in
+`authelia/certs/` automatically.
 
-Authelia also requires a dotted domain for session cookies (browser spec — `localhost` alone is on the Public Suffix List and can't have cookies set on it). Add this to `/etc/hosts` once:
+Authelia requires a dotted domain for session cookies. Add this to `/etc/hosts`
+once:
 
 ```
 127.0.0.1 localhost.localdomain
@@ -154,6 +211,6 @@ Authelia also requires a dotted domain for session cookies (browser spec — `lo
 
 ## Notes
 
-- This is a first-party trust model, not a public multi-tenant OAuth platform.
-- Sub-apps should not share the broker JWT signing secret.
-- Token verification is done by calling back to `haochen.lu /api/auth/me`.
+- First-party trust model only — not a public multi-tenant OAuth platform.
+- Apps must not share the broker JWT signing secret.
+- Token verification is always done by calling back to `/api/auth/me`.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -587,7 +587,10 @@ export const applications = {
   },
 
   create: async (
-    application: Omit<Application, "id" | "slug" | "created_at" | "updated_at">,
+    application: Omit<
+      Application,
+      "id" | "slug" | "order" | "created_at" | "updated_at"
+    >,
   ): Promise<Application> => {
     const response = await apiClient.post<Application>(
       "/applications",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -618,6 +618,13 @@ export const applications = {
     await apiClient.post("/applications/reorder", { items, normalize });
   },
 
+  regenerateCredentials: async (id: string): Promise<Application> => {
+    const response = await apiClient.post<Application>(
+      `/applications/${id}/regenerate-credentials`,
+    );
+    return response.data;
+  },
+
   getStats: async (): Promise<ApplicationStatsSummary> => {
     const response = await apiClient.get<ApplicationStatsSummary>(
       "/applications/stats/summary",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -611,6 +611,13 @@ export const applications = {
     await apiClient.delete(`/applications/${id}`);
   },
 
+  reorder: async (
+    items: Array<{ id: string; order: number }>,
+    normalize = true,
+  ): Promise<void> => {
+    await apiClient.post("/applications/reorder", { items, normalize });
+  },
+
   getStats: async (): Promise<ApplicationStatsSummary> => {
     const response = await apiClient.get<ApplicationStatsSummary>(
       "/applications/stats/summary",

--- a/frontend/src/components/AppForm.tsx
+++ b/frontend/src/components/AppForm.tsx
@@ -57,9 +57,9 @@ const AppForm: React.FC<AppFormProps> = ({
     },
   });
 
-  const watchUrl = useWatch<string | undefined>({ control, name: "url" });
-  const watchColor = useWatch<string | undefined>({ control, name: "color" });
-  const watchRequiresAuth = useWatch<boolean | undefined>({
+  const watchUrl = useWatch<AppFormData, "url">({ control, name: "url" });
+  const watchColor = useWatch<AppFormData, "color">({ control, name: "color" });
+  const watchRequiresAuth = useWatch<AppFormData, "requires_auth">({
     control,
     name: "requires_auth",
   });

--- a/frontend/src/components/AppForm.tsx
+++ b/frontend/src/components/AppForm.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { motion } from "framer-motion";
 import type { Application } from "../types";
 
@@ -38,7 +38,7 @@ const AppForm: React.FC<AppFormProps> = ({
   const {
     register,
     handleSubmit,
-    watch,
+    control,
     formState: { errors },
   } = useForm<AppFormData>({
     defaultValues: {
@@ -57,9 +57,12 @@ const AppForm: React.FC<AppFormProps> = ({
     },
   });
 
-  const watchUrl = watch("url");
-  const watchColor = watch("color");
-  const watchRequiresAuth = watch("requires_auth");
+  const watchUrl = useWatch<string | undefined>({ control, name: "url" });
+  const watchColor = useWatch<string | undefined>({ control, name: "color" });
+  const watchRequiresAuth = useWatch<boolean | undefined>({
+    control,
+    name: "requires_auth",
+  });
 
   const validateUrl = (value: string) => {
     try {

--- a/frontend/src/components/AppForm.tsx
+++ b/frontend/src/components/AppForm.tsx
@@ -15,7 +15,6 @@ interface AppFormData {
   admin_only: boolean;
   show_in_menu: boolean;
   enabled: boolean;
-  order: number;
   redirect_uris?: string;
 }
 
@@ -52,7 +51,6 @@ const AppForm: React.FC<AppFormProps> = ({
       admin_only: application?.admin_only ?? false,
       show_in_menu: application?.show_in_menu ?? true,
       enabled: application?.enabled ?? true,
-      order: application?.order ?? 0,
       redirect_uris: application?.redirect_uris ?? "",
     },
   });
@@ -245,31 +243,6 @@ const AppForm: React.FC<AppFormProps> = ({
                 {watchColor}
               </span>
             </div>
-          </div>
-
-          {/* Order Field */}
-          <div>
-            <label
-              htmlFor="order"
-              className="block text-sm font-medium text-foreground mb-2"
-            >
-              Display Order
-            </label>
-            <input
-              id="order"
-              type="number"
-              className="w-full px-3 py-2 border border-border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="0"
-              {...register("order", {
-                valueAsNumber: true,
-                min: { value: 0, message: "Order must be 0 or greater" },
-              })}
-            />
-            {errors.order && (
-              <p className="mt-1 text-sm text-red-600">
-                {errors.order.message}
-              </p>
-            )}
           </div>
         </div>
 

--- a/frontend/src/components/AppForm.tsx
+++ b/frontend/src/components/AppForm.tsx
@@ -13,7 +13,6 @@ interface AppFormData {
   is_external: boolean;
   requires_auth: boolean;
   admin_only: boolean;
-  show_in_menu: boolean;
   enabled: boolean;
   redirect_uris?: string;
 }
@@ -51,7 +50,6 @@ const AppForm: React.FC<AppFormProps> = ({
       is_external: application?.is_external ?? true,
       requires_auth: application?.requires_auth ?? false,
       admin_only: application?.admin_only ?? false,
-      show_in_menu: application?.show_in_menu ?? true,
       enabled: application?.enabled ?? true,
       redirect_uris: application?.redirect_uris ?? "",
     },
@@ -299,23 +297,6 @@ const AppForm: React.FC<AppFormProps> = ({
                 </span>
                 <p className="text-xs text-muted-foreground">
                   Only admins can access
-                </p>
-              </div>
-            </label>
-
-            {/* Show in Menu Toggle */}
-            <label className="flex items-center space-x-3 cursor-pointer">
-              <input
-                type="checkbox"
-                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-                {...register("show_in_menu")}
-              />
-              <div>
-                <span className="text-sm font-medium text-foreground">
-                  Show in Menu
-                </span>
-                <p className="text-xs text-muted-foreground">
-                  Display in navigation
                 </p>
               </div>
             </label>

--- a/frontend/src/components/AppForm.tsx
+++ b/frontend/src/components/AppForm.tsx
@@ -22,6 +22,7 @@ interface AppFormProps {
   application?: Application;
   onSubmit: (data: AppFormData) => Promise<void>;
   onCancel: () => void;
+  onRegenerateCredentials?: () => void;
   isLoading?: boolean;
 }
 
@@ -29,6 +30,7 @@ const AppForm: React.FC<AppFormProps> = ({
   application,
   onSubmit,
   onCancel,
+  onRegenerateCredentials,
   isLoading = false,
 }) => {
   const isEditing = !!application;
@@ -349,57 +351,68 @@ const AppForm: React.FC<AppFormProps> = ({
             </p>
             <div className="space-y-4">
               {isEditing && application?.client_id && (
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium text-foreground mb-1">
-                      Client ID
-                    </label>
-                    <div className="flex items-center gap-2">
-                      <input
-                        type="text"
-                        readOnly
-                        value={application.client_id}
-                        className="w-full px-3 py-2 border border-border rounded-lg bg-muted text-foreground font-mono text-sm"
-                      />
-                      <button
-                        type="button"
-                        onClick={() => {
-                          void navigator.clipboard.writeText(
-                            application.client_id ?? "",
-                          );
-                        }}
-                        className="px-2 py-2 text-xs text-muted-foreground hover:text-foreground border border-border rounded-lg transition-colors"
-                        title="Copy"
-                      >
-                        Copy
-                      </button>
+                <div className="space-y-3">
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                      <label className="block text-sm font-medium text-foreground mb-1">
+                        Client ID
+                      </label>
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="text"
+                          readOnly
+                          value={application.client_id}
+                          className="w-full px-3 py-2 border border-border rounded-lg bg-muted text-foreground font-mono text-sm"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => {
+                            void navigator.clipboard.writeText(
+                              application.client_id ?? "",
+                            );
+                          }}
+                          className="px-2 py-2 text-xs text-muted-foreground hover:text-foreground border border-border rounded-lg transition-colors"
+                          title="Copy"
+                        >
+                          Copy
+                        </button>
+                      </div>
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-foreground mb-1">
+                        Client Secret
+                      </label>
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="text"
+                          readOnly
+                          value={application.client_secret ?? ""}
+                          className="w-full px-3 py-2 border border-border rounded-lg bg-muted text-foreground font-mono text-sm"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => {
+                            void navigator.clipboard.writeText(
+                              application.client_secret ?? "",
+                            );
+                          }}
+                          className="px-2 py-2 text-xs text-muted-foreground hover:text-foreground border border-border rounded-lg transition-colors"
+                          title="Copy"
+                        >
+                          Copy
+                        </button>
+                      </div>
                     </div>
                   </div>
-                  <div>
-                    <label className="block text-sm font-medium text-foreground mb-1">
-                      Client Secret
-                    </label>
-                    <div className="flex items-center gap-2">
-                      <input
-                        type="text"
-                        readOnly
-                        value={application.client_secret ?? ""}
-                        className="w-full px-3 py-2 border border-border rounded-lg bg-muted text-foreground font-mono text-sm"
-                      />
-                      <button
-                        type="button"
-                        onClick={() => {
-                          void navigator.clipboard.writeText(
-                            application.client_secret ?? "",
-                          );
-                        }}
-                        className="px-2 py-2 text-xs text-muted-foreground hover:text-foreground border border-border rounded-lg transition-colors"
-                        title="Copy"
-                      >
-                        Copy
-                      </button>
-                    </div>
-                  </div>
+                  {onRegenerateCredentials && (
+                    <button
+                      type="button"
+                      onClick={onRegenerateCredentials}
+                      className="text-xs text-amber-600 hover:text-amber-700 underline underline-offset-2 transition-colors"
+                    >
+                      Regenerate client ID &amp; secret
+                    </button>
+                  )}
                 </div>
               )}
               {!isEditing && (

--- a/frontend/src/components/AppForm.tsx
+++ b/frontend/src/components/AppForm.tsx
@@ -13,6 +13,7 @@ interface AppFormData {
   is_external: boolean;
   requires_auth: boolean;
   admin_only: boolean;
+  logged_in_only: boolean;
   enabled: boolean;
   redirect_uris?: string;
 }
@@ -50,6 +51,7 @@ const AppForm: React.FC<AppFormProps> = ({
       is_external: application?.is_external ?? true,
       requires_auth: application?.requires_auth ?? false,
       admin_only: application?.admin_only ?? false,
+      logged_in_only: application?.logged_in_only ?? false,
       enabled: application?.enabled ?? true,
       redirect_uris: application?.redirect_uris ?? "",
     },
@@ -297,6 +299,23 @@ const AppForm: React.FC<AppFormProps> = ({
                 </span>
                 <p className="text-xs text-muted-foreground">
                   Only admins can access
+                </p>
+              </div>
+            </label>
+
+            {/* Logged In Only Toggle */}
+            <label className="flex items-center space-x-3 cursor-pointer">
+              <input
+                type="checkbox"
+                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                {...register("logged_in_only")}
+              />
+              <div>
+                <span className="text-sm font-medium text-foreground">
+                  Logged In Only
+                </span>
+                <p className="text-xs text-muted-foreground">
+                  Only show in navbar when logged in
                 </p>
               </div>
             </label>

--- a/frontend/src/components/AppList.tsx
+++ b/frontend/src/components/AppList.tsx
@@ -6,8 +6,8 @@ import {
   closestCenter,
   useSensor,
   useSensors,
+  type DragEndEvent,
 } from "@dnd-kit/core";
-import type { DragEndEvent } from "@dnd-kit/core";
 import {
   SortableContext,
   arrayMove,

--- a/frontend/src/components/AppList.tsx
+++ b/frontend/src/components/AppList.tsx
@@ -64,14 +64,12 @@ function OverflowMenu({
 
   return (
     <div ref={ref} className="relative">
-      <Button
-        variant="outline"
-        size="sm"
+      <button
         onClick={() => setOpen((v) => !v)}
-        className="px-2"
+        className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
       >
         <MoreVertical className="h-4 w-4" />
-      </Button>
+      </button>
       <AnimatePresence>
         {open && (
           <motion.div

--- a/frontend/src/components/AppList.tsx
+++ b/frontend/src/components/AppList.tsx
@@ -15,7 +15,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { Check, Copy, GripVertical, MoreVertical } from "lucide-react";
+import { GripVertical, MoreVertical } from "lucide-react";
 import type { Application } from "../types";
 import { formatDateSimple } from "../utils/dateFormat";
 import { applications as applicationsApi } from "../api/client";
@@ -30,25 +30,6 @@ interface AppListProps {
   onOpenAdmin: (application: Application) => void;
   onReorder: (items: Array<{ id: string; order: number }>) => void;
   isLoading?: boolean;
-}
-
-function CopyButton({ value }: { value: string }) {
-  const [copied, setCopied] = useState(false);
-  return (
-    <button
-      type="button"
-      onClick={() => {
-        void navigator.clipboard.writeText(value).then(() => {
-          setCopied(true);
-          setTimeout(() => setCopied(false), 1500);
-        });
-      }}
-      className="ml-1 p-0.5 rounded text-muted-foreground hover:text-foreground transition-colors"
-      title="Copy"
-    >
-      {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-    </button>
-  );
 }
 
 function OverflowMenu({
@@ -303,23 +284,6 @@ function SortableAppCard({
             <span>·</span>
             <span>{formatDateSimple(application.created_at)}</span>
           </div>
-
-          {application.requires_auth && application.client_id && (
-            <div className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-1 text-xs font-mono">
-              <div className="flex items-center gap-1 text-muted-foreground">
-                <span className="text-foreground/50 shrink-0">client_id</span>
-                <span className="truncate">{application.client_id}</span>
-                <CopyButton value={application.client_id} />
-              </div>
-              {application.client_secret && (
-                <div className="flex items-center gap-1 text-muted-foreground">
-                  <span className="text-foreground/50 shrink-0">secret</span>
-                  <span className="truncate">{application.client_secret}</span>
-                  <CopyButton value={application.client_secret} />
-                </div>
-              )}
-            </div>
-          )}
         </div>
 
         {/* Actions */}

--- a/frontend/src/components/AppList.tsx
+++ b/frontend/src/components/AppList.tsx
@@ -259,11 +259,6 @@ function SortableAppCard({
                 public
               </span>
             )}
-            {!application.show_in_menu && (
-              <span className="px-1.5 py-0.5 rounded text-xs bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400">
-                hidden
-              </span>
-            )}
           </div>
 
           {application.description && (

--- a/frontend/src/components/AppList.tsx
+++ b/frontend/src/components/AppList.tsx
@@ -245,6 +245,11 @@ function SortableAppCard({
                 disabled
               </span>
             )}
+            {application.logged_in_only && !application.admin_only && (
+              <span className="px-1.5 py-0.5 rounded text-xs bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+                logged in only
+              </span>
+            )}
             {application.admin_only && (
               <span className="px-1.5 py-0.5 rounded text-xs bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">
                 admin only

--- a/frontend/src/components/AppList.tsx
+++ b/frontend/src/components/AppList.tsx
@@ -216,19 +216,24 @@ function SortableAppCard({
       }`}
     >
       <div className="flex items-start gap-3">
-        {/* Drag handle — only visible when reorder is enabled */}
-        <button
-          {...attributes}
-          {...listeners}
-          className={`mt-0.5 p-1 rounded transition-colors cursor-grab active:cursor-grabbing shrink-0 ${
-            reorderEnabled
-              ? "text-amber-500 hover:text-amber-600 hover:bg-amber-100/50 dark:hover:bg-amber-900/20"
-              : "invisible pointer-events-none"
-          }`}
-          title="Drag to reorder"
-        >
-          <GripVertical className="h-4 w-4" />
-        </button>
+        {/* Drag handle — animated in/out */}
+        <AnimatePresence initial={false}>
+          {reorderEnabled && (
+            <motion.button
+              key="grip"
+              {...attributes}
+              {...listeners}
+              initial={{ opacity: 0, width: 0 }}
+              animate={{ opacity: 1, width: "auto" }}
+              exit={{ opacity: 0, width: 0 }}
+              transition={{ duration: 0.15 }}
+              className="mt-0.5 p-1 rounded text-amber-500 hover:text-amber-600 hover:bg-amber-100/50 dark:hover:bg-amber-900/20 cursor-grab active:cursor-grabbing shrink-0 overflow-hidden"
+              title="Drag to reorder"
+            >
+              <GripVertical className="h-4 w-4" />
+            </motion.button>
+          )}
+        </AnimatePresence>
 
         {/* Icon */}
         <div

--- a/frontend/src/components/AppList.tsx
+++ b/frontend/src/components/AppList.tsx
@@ -16,6 +16,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { GripVertical, MoreVertical } from "lucide-react";
+import { Button } from "./ui/button";
 import type { Application } from "../types";
 import { formatDateSimple } from "../utils/dateFormat";
 import { applications as applicationsApi } from "../api/client";
@@ -63,12 +64,14 @@ function OverflowMenu({
 
   return (
     <div ref={ref} className="relative">
-      <button
+      <Button
+        variant="outline"
+        size="sm"
         onClick={() => setOpen((v) => !v)}
-        className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+        className="px-2"
       >
         <MoreVertical className="h-4 w-4" />
-      </button>
+      </Button>
       <AnimatePresence>
         {open && (
           <motion.div
@@ -196,7 +199,7 @@ function SortableAppCard({
             : "border-border hover:border-border/60"
       }`}
     >
-      <div className="flex items-start gap-3">
+      <div className="flex items-center gap-3">
         {/* Drag handle — animated in/out */}
         <AnimatePresence initial={false}>
           {reorderEnabled && (
@@ -208,7 +211,7 @@ function SortableAppCard({
               animate={{ opacity: 1, width: "auto" }}
               exit={{ opacity: 0, width: 0 }}
               transition={{ duration: 0.15 }}
-              className="mt-0.5 p-1 rounded text-amber-500 hover:text-amber-600 hover:bg-amber-100/50 dark:hover:bg-amber-900/20 cursor-grab active:cursor-grabbing shrink-0 overflow-hidden"
+              className="p-1 rounded text-amber-500 hover:text-amber-600 hover:bg-amber-100/50 dark:hover:bg-amber-900/20 cursor-grab active:cursor-grabbing shrink-0 overflow-hidden"
               title="Drag to reorder"
             >
               <GripVertical className="h-4 w-4" />
@@ -282,20 +285,14 @@ function SortableAppCard({
         </div>
 
         {/* Actions */}
-        <div className="flex items-center gap-1 shrink-0">
-          <button
-            onClick={onOpen}
-            className="px-2.5 py-1.5 text-xs font-medium text-emerald-700 bg-emerald-100 hover:bg-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-400 rounded transition-colors"
-          >
+        <div className="flex items-center gap-2 shrink-0">
+          <Button variant="outline" size="sm" onClick={onOpen}>
             Open
-          </button>
+          </Button>
           {application.admin_url && (
-            <button
-              onClick={onOpenAdmin}
-              className="px-2.5 py-1.5 text-xs font-medium text-violet-700 bg-violet-100 hover:bg-violet-200 dark:bg-violet-900/30 dark:text-violet-400 rounded transition-colors"
-            >
+            <Button variant="outline" size="sm" onClick={onOpenAdmin}>
               Admin
-            </button>
+            </Button>
           )}
           <OverflowMenu
             application={application}

--- a/frontend/src/components/AppList.tsx
+++ b/frontend/src/components/AppList.tsx
@@ -1,5 +1,21 @@
-import React, { useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import React, { useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import type { DragEndEvent } from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Check, Copy, GripVertical, MoreVertical } from "lucide-react";
 import type { Application } from "../types";
 import { formatDateSimple } from "../utils/dateFormat";
 import { applications as applicationsApi } from "../api/client";
@@ -11,7 +27,314 @@ interface AppListProps {
   onToggleEnabled: (applicationId: string, enabled: boolean) => void;
   onOpen: (application: Application) => void;
   onOpenAdmin: (application: Application) => void;
+  onReorder: (items: Array<{ id: string; order: number }>) => void;
   isLoading?: boolean;
+}
+
+function CopyButton({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        void navigator.clipboard.writeText(value).then(() => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        });
+      }}
+      className="ml-1 p-0.5 rounded text-muted-foreground hover:text-foreground transition-colors"
+      title="Copy"
+    >
+      {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+    </button>
+  );
+}
+
+function OverflowMenu({
+  application,
+  onEdit,
+  onDelete,
+  onToggleEnabled,
+  onExport,
+}: {
+  application: Application;
+  onEdit: () => void;
+  onDelete: () => void;
+  onToggleEnabled: () => void;
+  onExport: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+        setConfirmDelete(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+      >
+        <MoreVertical className="h-4 w-4" />
+      </button>
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95, y: -4 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: -4 }}
+            transition={{ duration: 0.1 }}
+            className="absolute right-0 z-50 mt-1 w-44 rounded-lg border border-border bg-popover shadow-lg"
+          >
+            <div className="py-1">
+              <button
+                onClick={() => {
+                  onEdit();
+                  setOpen(false);
+                }}
+                className="w-full px-3 py-2 text-left text-sm hover:bg-muted transition-colors"
+              >
+                Edit
+              </button>
+              <button
+                onClick={() => {
+                  onToggleEnabled();
+                  setOpen(false);
+                }}
+                className="w-full px-3 py-2 text-left text-sm hover:bg-muted transition-colors"
+              >
+                {application.enabled ? "Disable" : "Enable"}
+              </button>
+              <button
+                onClick={() => {
+                  onExport();
+                  setOpen(false);
+                }}
+                className="w-full px-3 py-2 text-left text-sm hover:bg-muted transition-colors"
+              >
+                Export YAML
+              </button>
+              <div className="border-t border-border my-1" />
+              {confirmDelete ? (
+                <div className="px-3 py-2">
+                  <p className="text-xs text-muted-foreground mb-2">
+                    Delete this app?
+                  </p>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => {
+                        onDelete();
+                        setOpen(false);
+                        setConfirmDelete(false);
+                      }}
+                      className="flex-1 px-2 py-1 text-xs font-medium text-white bg-red-600 hover:bg-red-700 rounded transition-colors"
+                    >
+                      Delete
+                    </button>
+                    <button
+                      onClick={() => setConfirmDelete(false)}
+                      className="flex-1 px-2 py-1 text-xs font-medium bg-muted hover:bg-muted/80 rounded transition-colors"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <button
+                  onClick={() => setConfirmDelete(true)}
+                  className="w-full px-3 py-2 text-left text-sm text-red-600 hover:bg-muted transition-colors"
+                >
+                  Delete
+                </button>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+function SortableAppCard({
+  application,
+  onEdit,
+  onDelete,
+  onToggleEnabled,
+  onOpen,
+  onOpenAdmin,
+  onExport,
+}: {
+  application: Application;
+  onEdit: () => void;
+  onDelete: () => void;
+  onToggleEnabled: () => void;
+  onOpen: () => void;
+  onOpenAdmin: () => void;
+  onExport: () => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: application.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const icon = application.icon;
+  const initial = application.name.charAt(0).toUpperCase();
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`bg-card rounded-lg border p-4 transition-colors ${
+        isDragging
+          ? "border-blue-400 shadow-lg"
+          : "border-border hover:border-border/60"
+      }`}
+    >
+      <div className="flex items-start gap-3">
+        {/* Drag handle */}
+        <button
+          {...attributes}
+          {...listeners}
+          className="mt-0.5 p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-grab active:cursor-grabbing shrink-0"
+          title="Drag to reorder"
+        >
+          <GripVertical className="h-4 w-4" />
+        </button>
+
+        {/* Icon */}
+        <div
+          className="h-10 w-10 rounded-lg flex items-center justify-center shrink-0 text-white text-sm font-semibold"
+          style={{ backgroundColor: application.color ?? "#3B82F6" }}
+        >
+          {icon && icon.length <= 2 ? (
+            <span className="text-base">{icon}</span>
+          ) : icon ? (
+            <img src={icon} alt="" className="h-6 w-6 object-contain" />
+          ) : (
+            initial
+          )}
+        </div>
+
+        {/* Main content */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-medium text-foreground">
+              {application.name}
+            </span>
+            <span className="text-xs text-muted-foreground font-mono">
+              {application.slug}
+            </span>
+            {!application.enabled && (
+              <span className="px-1.5 py-0.5 rounded text-xs bg-muted text-muted-foreground">
+                disabled
+              </span>
+            )}
+            {application.admin_only && (
+              <span className="px-1.5 py-0.5 rounded text-xs bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400">
+                admin only
+              </span>
+            )}
+            {application.requires_auth && !application.admin_only && (
+              <span className="px-1.5 py-0.5 rounded text-xs bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400">
+                auth
+              </span>
+            )}
+            {!application.requires_auth && application.enabled && (
+              <span className="px-1.5 py-0.5 rounded text-xs bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">
+                public
+              </span>
+            )}
+            {!application.show_in_menu && (
+              <span className="px-1.5 py-0.5 rounded text-xs bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400">
+                hidden
+              </span>
+            )}
+          </div>
+
+          {application.description && (
+            <p className="mt-1 text-sm text-muted-foreground truncate">
+              {application.description}
+            </p>
+          )}
+
+          <div className="mt-1 flex items-center gap-3 text-xs text-muted-foreground flex-wrap">
+            <a
+              href={application.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 hover:underline truncate max-w-xs"
+            >
+              {application.url}
+            </a>
+            <span>·</span>
+            <span>{formatDateSimple(application.created_at)}</span>
+          </div>
+
+          {application.requires_auth && application.client_id && (
+            <div className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-1 text-xs font-mono">
+              <div className="flex items-center gap-1 text-muted-foreground">
+                <span className="text-foreground/50 shrink-0">client_id</span>
+                <span className="truncate">{application.client_id}</span>
+                <CopyButton value={application.client_id} />
+              </div>
+              {application.client_secret && (
+                <div className="flex items-center gap-1 text-muted-foreground">
+                  <span className="text-foreground/50 shrink-0">secret</span>
+                  <span className="truncate">{application.client_secret}</span>
+                  <CopyButton value={application.client_secret} />
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-1 shrink-0">
+          <button
+            onClick={onOpen}
+            className="px-2.5 py-1.5 text-xs font-medium text-emerald-700 bg-emerald-100 hover:bg-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-400 rounded transition-colors"
+          >
+            Open
+          </button>
+          {application.admin_url && (
+            <button
+              onClick={onOpenAdmin}
+              className="px-2.5 py-1.5 text-xs font-medium text-violet-700 bg-violet-100 hover:bg-violet-200 dark:bg-violet-900/30 dark:text-violet-400 rounded transition-colors"
+            >
+              Admin
+            </button>
+          )}
+          <OverflowMenu
+            application={application}
+            onEdit={onEdit}
+            onDelete={onDelete}
+            onToggleEnabled={onToggleEnabled}
+            onExport={onExport}
+          />
+        </div>
+      </div>
+    </div>
+  );
 }
 
 const AppList: React.FC<AppListProps> = ({
@@ -21,11 +344,32 @@ const AppList: React.FC<AppListProps> = ({
   onToggleEnabled,
   onOpen,
   onOpenAdmin,
+  onReorder,
   isLoading = false,
 }) => {
-  const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
   const [exportingId, setExportingId] = useState<string | null>(null);
+  const [localApps, setLocalApps] = useState<Application[]>(applications);
+
+  React.useEffect(() => {
+    setLocalApps(applications);
+  }, [applications]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { delay: 150, tolerance: 5 },
+    }),
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = localApps.findIndex((a) => a.id === active.id);
+    const newIndex = localApps.findIndex((a) => a.id === over.id);
+    const reordered = arrayMove(localApps, oldIndex, newIndex);
+    setLocalApps(reordered);
+    onReorder(reordered.map((a, i) => ({ id: a.id, order: i })));
+  };
 
   const handleExport = async (application: Application) => {
     setExportingId(application.id);
@@ -36,113 +380,29 @@ const AppList: React.FC<AppListProps> = ({
     }
   };
 
-  const filteredApplications = applications.filter(
-    (app) =>
-      app.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      app.url.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      app.description?.toLowerCase().includes(searchTerm.toLowerCase()),
-  );
-
-  const handleDeleteClick = (applicationId: string) => {
-    setDeleteConfirm(applicationId);
-  };
-
-  const handleDeleteConfirm = (applicationId: string) => {
-    onDelete(applicationId);
-    setDeleteConfirm(null);
-  };
-
-  const handleDeleteCancel = () => {
-    setDeleteConfirm(null);
-  };
-
-  const getStatusBadge = (application: Application) => {
-    if (!application.enabled) {
-      return (
-        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
-          Disabled
-        </span>
-      );
-    }
-
-    if (application.admin_only) {
-      return (
-        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
-          Admin Only
-        </span>
-      );
-    }
-
-    if (application.requires_auth) {
-      return (
-        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
-          Auth Required
-        </span>
-      );
-    }
-
-    return (
-      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-        Public
-      </span>
-    );
-  };
-
-  const renderIcon = (application: Application) => {
-    if (!application.icon) {
-      return (
-        <div className="h-8 w-8 bg-gray-200 rounded-lg flex items-center justify-center">
-          <span className="text-gray-500 text-sm font-medium">
-            {application.name.charAt(0).toUpperCase()}
-          </span>
-        </div>
-      );
-    }
-
-    // Check if icon is an emoji (single character) or URL
-    if (application.icon.length <= 2) {
-      return (
-        <div className="h-8 w-8 flex items-center justify-center text-lg">
-          {application.icon}
-        </div>
-      );
-    }
-
-    // Assume it's an image URL
-    return (
-      <img
-        src={application.icon}
-        alt={`${application.name} icon`}
-        className="h-8 w-8 rounded-lg object-cover"
-        onError={(e) => {
-          // Fallback to initial letter if image fails to load
-          const target = e.target as HTMLImageElement;
-          target.style.display = "none";
-          const fallback = target.parentElement?.querySelector(".fallback");
-          if (fallback) {
-            (fallback as HTMLElement).style.display = "flex";
-          }
-        }}
-      />
-    );
-  };
+  const filtered = searchTerm
+    ? localApps.filter(
+        (app) =>
+          app.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          app.url.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          app.description?.toLowerCase().includes(searchTerm.toLowerCase()),
+      )
+    : localApps;
 
   if (isLoading) {
     return (
-      <div className="space-y-4">
-        {Array.from({ length: 3 }).map((_, index) => (
+      <div className="space-y-3">
+        {Array.from({ length: 3 }).map((_, i) => (
           <div
-            key={index}
-            className="bg-card rounded-lg border border-border p-6"
+            key={i}
+            className="bg-card rounded-lg border border-border p-4 animate-pulse"
           >
-            <div className="animate-pulse">
-              <div className="flex items-center space-x-4">
-                <div className="h-8 w-8 bg-muted rounded-lg" />
-                <div className="flex-1">
-                  <div className="h-4 bg-muted rounded w-1/4 mb-2" />
-                  <div className="h-3 bg-muted rounded w-1/2" />
-                </div>
-                <div className="h-6 bg-muted rounded-full w-16" />
+            <div className="flex items-center gap-3">
+              <div className="h-4 w-4 bg-muted rounded" />
+              <div className="h-10 w-10 bg-muted rounded-lg" />
+              <div className="flex-1 space-y-2">
+                <div className="h-4 bg-muted rounded w-1/4" />
+                <div className="h-3 bg-muted rounded w-1/2" />
               </div>
             </div>
           </div>
@@ -153,206 +413,65 @@ const AppList: React.FC<AppListProps> = ({
 
   return (
     <div>
-      {/* Search Bar */}
-      <div className="mb-6">
-        <div className="relative">
-          <input
-            type="text"
-            placeholder="Search apps..."
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 border border-border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-blue-500"
+      <div className="mb-4 relative">
+        <input
+          type="text"
+          placeholder="Search apps..."
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          className="w-full pl-9 pr-4 py-2 border border-border rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
+        />
+        <svg
+          className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
           />
-          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <svg
-              className="h-5 w-5 text-gray-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-              />
-            </svg>
-          </div>
-        </div>
+        </svg>
       </div>
 
-      {/* Applications List */}
-      <AnimatePresence>
-        {filteredApplications.length === 0 ? (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            className="text-center py-12"
+      {filtered.length === 0 ? (
+        <div className="text-center py-12 text-muted-foreground text-sm">
+          {searchTerm
+            ? "No apps match your search."
+            : "No apps yet. Create your first one!"}
+        </div>
+      ) : (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={filtered.map((a) => a.id)}
+            strategy={verticalListSortingStrategy}
           >
-            <div className="text-gray-500">
-              {searchTerm
-                ? "No apps match your search."
-                : "No apps found. Create your first one!"}
+            <div className="space-y-3">
+              {filtered.map((app) => (
+                <SortableAppCard
+                  key={app.id}
+                  application={app}
+                  onEdit={() => onEdit(app)}
+                  onDelete={() => onDelete(app.id)}
+                  onToggleEnabled={() => onToggleEnabled(app.id, !app.enabled)}
+                  onOpen={() => onOpen(app)}
+                  onOpenAdmin={() => onOpenAdmin(app)}
+                  onExport={() => {
+                    void handleExport(app);
+                  }}
+                />
+              ))}
             </div>
-          </motion.div>
-        ) : (
-          <div className="space-y-4">
-            {filteredApplications.map((application) => (
-              <motion.div
-                key={application.id}
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: -20 }}
-                className="bg-card rounded-lg border border-border p-6 hover:border-border/80 transition-colors"
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center space-x-4 flex-1">
-                    {/* Icon */}
-                    <div className="relative">
-                      {renderIcon(application)}
-                      <div className="fallback h-8 w-8 bg-gray-200 rounded-lg hidden items-center justify-center">
-                        <span className="text-gray-500 text-sm font-medium">
-                          {application.name.charAt(0).toUpperCase()}
-                        </span>
-                      </div>
-                    </div>
-
-                    {/* Content */}
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center space-x-3">
-                        <h3 className="text-lg font-medium text-foreground truncate">
-                          {application.name}
-                        </h3>
-                        {getStatusBadge(application)}
-                        {application.is_external && (
-                          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                            External
-                          </span>
-                        )}
-                        {!application.show_in_menu && (
-                          <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-orange-100 text-orange-800">
-                            Hidden
-                          </span>
-                        )}
-                      </div>
-
-                      <div className="mt-1">
-                        <a
-                          href={application.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-sm text-blue-600 hover:text-blue-800 hover:underline truncate block"
-                        >
-                          {application.url}
-                        </a>
-                      </div>
-
-                      {application.description && (
-                        <p className="mt-2 text-sm text-muted-foreground line-clamp-2">
-                          {application.description}
-                        </p>
-                      )}
-
-                      <div className="mt-2 flex items-center text-xs text-muted-foreground space-x-4">
-                        <span>Order: {application.order}</span>
-                        <span>
-                          Created: {formatDateSimple(application.created_at)}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Actions */}
-                  <div className="flex items-center space-x-2 ml-4">
-                    <button
-                      onClick={() => onOpen(application)}
-                      className="px-3 py-1.5 text-xs font-medium text-emerald-700 bg-emerald-100 hover:bg-emerald-200 rounded transition-colors"
-                      title="Open App"
-                    >
-                      Open
-                    </button>
-
-                    {application.admin_url && (
-                      <button
-                        onClick={() => onOpenAdmin(application)}
-                        className="px-3 py-1.5 text-xs font-medium text-violet-700 bg-violet-100 hover:bg-violet-200 rounded transition-colors"
-                        title="Open Admin"
-                      >
-                        Admin
-                      </button>
-                    )}
-
-                    {/* Toggle Enable/Disable */}
-                    <button
-                      onClick={() =>
-                        onToggleEnabled(application.id, !application.enabled)
-                      }
-                      className={`px-3 py-1.5 text-xs font-medium rounded transition-colors ${
-                        application.enabled
-                          ? "text-orange-700 bg-orange-100 hover:bg-orange-200"
-                          : "text-green-700 bg-green-100 hover:bg-green-200"
-                      }`}
-                      title={application.enabled ? "Disable" : "Enable"}
-                    >
-                      {application.enabled ? "Disable" : "Enable"}
-                    </button>
-
-                    {/* Export Button */}
-                    <button
-                      onClick={() => {
-                        void handleExport(application);
-                      }}
-                      disabled={exportingId === application.id}
-                      className="px-3 py-1.5 text-xs font-medium text-cyan-700 bg-cyan-100 hover:bg-cyan-200 disabled:opacity-50 rounded transition-colors"
-                      title="Export YAML"
-                    >
-                      {exportingId === application.id ? "..." : "Export"}
-                    </button>
-
-                    {/* Edit Button */}
-                    <button
-                      onClick={() => onEdit(application)}
-                      className="px-3 py-1.5 text-xs font-medium text-blue-700 bg-blue-100 hover:bg-blue-200 rounded transition-colors"
-                      title="Edit"
-                    >
-                      Edit
-                    </button>
-
-                    {/* Delete Button */}
-                    {deleteConfirm === application.id ? (
-                      <div className="flex space-x-1">
-                        <button
-                          onClick={() => handleDeleteConfirm(application.id)}
-                          className="px-2 py-1.5 text-xs font-medium text-red-700 bg-red-100 hover:bg-red-200 rounded transition-colors"
-                          title="Confirm Delete"
-                        >
-                          Yes
-                        </button>
-                        <button
-                          onClick={handleDeleteCancel}
-                          className="px-2 py-1.5 text-xs font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded transition-colors"
-                          title="Cancel Delete"
-                        >
-                          No
-                        </button>
-                      </div>
-                    ) : (
-                      <button
-                        onClick={() => handleDeleteClick(application.id)}
-                        className="px-3 py-1.5 text-xs font-medium text-red-700 bg-red-100 hover:bg-red-200 rounded transition-colors"
-                        title="Delete"
-                      >
-                        Delete
-                      </button>
-                    )}
-                  </div>
-                </div>
-              </motion.div>
-            ))}
-          </div>
-        )}
-      </AnimatePresence>
+          </SortableContext>
+        </DndContext>
+      )}
+      {exportingId && <span className="sr-only">Exporting...</span>}
     </div>
   );
 };

--- a/frontend/src/components/AppList.tsx
+++ b/frontend/src/components/AppList.tsx
@@ -22,6 +22,7 @@ import { applications as applicationsApi } from "../api/client";
 
 interface AppListProps {
   applications: Application[];
+  reorderEnabled?: boolean;
   onEdit: (application: Application) => void;
   onDelete: (applicationId: string) => void;
   onToggleEnabled: (applicationId: string, enabled: boolean) => void;
@@ -167,6 +168,7 @@ function OverflowMenu({
 
 function SortableAppCard({
   application,
+  reorderEnabled,
   onEdit,
   onDelete,
   onToggleEnabled,
@@ -175,6 +177,7 @@ function SortableAppCard({
   onExport,
 }: {
   application: Application;
+  reorderEnabled: boolean;
   onEdit: () => void;
   onDelete: () => void;
   onToggleEnabled: () => void;
@@ -206,16 +209,22 @@ function SortableAppCard({
       style={style}
       className={`bg-card rounded-lg border p-4 transition-colors ${
         isDragging
-          ? "border-blue-400 shadow-lg"
-          : "border-border hover:border-border/60"
+          ? "border-amber-400 shadow-lg ring-1 ring-amber-400/50"
+          : reorderEnabled
+            ? "border-amber-300/60 bg-amber-50/30 dark:bg-amber-900/10"
+            : "border-border hover:border-border/60"
       }`}
     >
       <div className="flex items-start gap-3">
-        {/* Drag handle */}
+        {/* Drag handle — only visible when reorder is enabled */}
         <button
           {...attributes}
           {...listeners}
-          className="mt-0.5 p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-grab active:cursor-grabbing shrink-0"
+          className={`mt-0.5 p-1 rounded transition-colors cursor-grab active:cursor-grabbing shrink-0 ${
+            reorderEnabled
+              ? "text-amber-500 hover:text-amber-600 hover:bg-amber-100/50 dark:hover:bg-amber-900/20"
+              : "invisible pointer-events-none"
+          }`}
           title="Drag to reorder"
         >
           <GripVertical className="h-4 w-4" />
@@ -339,6 +348,7 @@ function SortableAppCard({
 
 const AppList: React.FC<AppListProps> = ({
   applications,
+  reorderEnabled = false,
   onEdit,
   onDelete,
   onToggleEnabled,
@@ -362,6 +372,7 @@ const AppList: React.FC<AppListProps> = ({
   );
 
   const handleDragEnd = (event: DragEndEvent) => {
+    if (!reorderEnabled) return;
     const { active, over } = event;
     if (!over || active.id === over.id) return;
     const oldIndex = localApps.findIndex((a) => a.id === active.id);
@@ -457,6 +468,7 @@ const AppList: React.FC<AppListProps> = ({
                 <SortableAppCard
                   key={app.id}
                   application={app}
+                  reorderEnabled={reorderEnabled}
                   onEdit={() => onEdit(app)}
                   onDelete={() => onDelete(app.id)}
                   onToggleEnabled={() => onToggleEnabled(app.id, !app.enabled)}

--- a/frontend/src/hooks/useApplications.ts
+++ b/frontend/src/hooks/useApplications.ts
@@ -190,6 +190,32 @@ export const useToggleAppEnabled = () => {
   });
 };
 
+export const useRegenerateCredentials = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => applications.regenerateCredentials(id),
+    onSuccess: (updatedApp) => {
+      queryClient.setQueryData(
+        appKeys.list("admin"),
+        (old: ApplicationListResponse | undefined) => {
+          if (!old) return old;
+          return {
+            ...old,
+            applications: old.applications.map((app) =>
+              app.id === updatedApp.id ? updatedApp : app,
+            ),
+          };
+        },
+      );
+      toast.success("Credentials regenerated");
+    },
+    onError: () => {
+      toast.error("Failed to regenerate credentials");
+    },
+  });
+};
+
 export const useReorderApplications = () => {
   const queryClient = useQueryClient();
 

--- a/frontend/src/hooks/useApplications.ts
+++ b/frontend/src/hooks/useApplications.ts
@@ -190,6 +190,46 @@ export const useToggleAppEnabled = () => {
   });
 };
 
+export const useReorderApplications = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (items: Array<{ id: string; order: number }>) =>
+      applications.reorder(items, true),
+    onMutate: async (items) => {
+      await queryClient.cancelQueries({ queryKey: appKeys.list("admin") });
+      const previous = queryClient.getQueryData<ApplicationListResponse>(
+        appKeys.list("admin"),
+      );
+      const orderMap = new Map(items.map((i) => [i.id, i.order]));
+      queryClient.setQueryData(
+        appKeys.list("admin"),
+        (old: ApplicationListResponse | undefined) => {
+          if (!old) return old;
+          return {
+            ...old,
+            applications: [...old.applications].sort(
+              (a, b) =>
+                (orderMap.get(a.id) ?? a.order) -
+                (orderMap.get(b.id) ?? b.order),
+            ),
+          };
+        },
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(appKeys.list("admin"), context.previous);
+      }
+      toast.error("Failed to reorder applications");
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: appKeys.lists() });
+    },
+  });
+};
+
 export const useBulkUpdateApplications = () => {
   const queryClient = useQueryClient();
 

--- a/frontend/src/hooks/useApplications.ts
+++ b/frontend/src/hooks/useApplications.ts
@@ -54,7 +54,10 @@ export const useCreateApplication = () => {
 
   return useMutation({
     mutationFn: (
-      data: Omit<Application, "id" | "slug" | "created_at" | "updated_at">,
+      data: Omit<
+        Application,
+        "id" | "slug" | "order" | "created_at" | "updated_at"
+      >,
     ) => applications.create(data),
     onSuccess: (newApp) => {
       void queryClient.invalidateQueries({ queryKey: appKeys.lists() });

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -6,7 +6,6 @@ import { useQuery } from "@tanstack/react-query";
 
 import { applications, content } from "../api/client";
 import { useAuthStore } from "../stores/authStore";
-import { useRef } from "react";
 
 const MainLayout: React.FC = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -33,6 +33,10 @@ const MainLayout: React.FC = () => {
     queryFn: () => applications.list(),
   });
 
+  const visibleApps = (subAppsData?.applications ?? []).filter(
+    (app) => !app.logged_in_only || isAuthenticated,
+  );
+
   // Fetch footer content
   const { data: footerContent } = useQuery({
     queryKey: ["content", "footer"],
@@ -117,49 +121,48 @@ const MainLayout: React.FC = () => {
               ))}
 
               {/* Sub-apps dropdown or direct links */}
-              {subAppsData?.applications &&
-                subAppsData.applications.length > 0 && (
-                  <div className="relative group">
-                    <button
-                      className={`px-3 text-foreground hover:text-primary transition-all duration-300 ease-out ${navPadding} ${navClasses}`}
-                    >
-                      Apps
-                    </button>
-                    <div className="absolute left-0 mt-2 w-56 bg-white rounded-md shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50">
-                      <div className="py-1">
-                        {subAppsData.applications.map((app) => {
-                          return (
-                            <button
-                              key={app.id}
-                              type="button"
-                              onClick={() => {
-                                void handleAppNavigation(app);
-                              }}
-                              className="flex w-full items-center px-4 py-2 text-sm text-foreground hover:bg-gray-50 hover:text-primary transition-colors duration-200"
-                            >
-                              {app.icon && (
-                                <span
-                                  className="mr-3 text-lg"
-                                  style={{ color: app.color ?? undefined }}
-                                >
-                                  {app.icon}
-                                </span>
+              {visibleApps.length > 0 && (
+                <div className="relative group">
+                  <button
+                    className={`px-3 text-foreground hover:text-primary transition-all duration-300 ease-out ${navPadding} ${navClasses}`}
+                  >
+                    Apps
+                  </button>
+                  <div className="absolute left-0 mt-2 w-56 bg-white rounded-md shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50">
+                    <div className="py-1">
+                      {visibleApps.map((app) => {
+                        return (
+                          <button
+                            key={app.id}
+                            type="button"
+                            onClick={() => {
+                              void handleAppNavigation(app);
+                            }}
+                            className="flex w-full items-center px-4 py-2 text-sm text-foreground hover:bg-gray-50 hover:text-primary transition-colors duration-200"
+                          >
+                            {app.icon && (
+                              <span
+                                className="mr-3 text-lg"
+                                style={{ color: app.color ?? undefined }}
+                              >
+                                {app.icon}
+                              </span>
+                            )}
+                            <div>
+                              <div className="font-medium">{app.name}</div>
+                              {app.description && (
+                                <div className="text-xs text-muted-foreground">
+                                  {app.description}
+                                </div>
                               )}
-                              <div>
-                                <div className="font-medium">{app.name}</div>
-                                {app.description && (
-                                  <div className="text-xs text-muted-foreground">
-                                    {app.description}
-                                  </div>
-                                )}
-                              </div>
-                            </button>
-                          );
-                        })}
-                      </div>
+                            </div>
+                          </button>
+                        );
+                      })}
                     </div>
                   </div>
-                )}
+                </div>
+              )}
             </nav>
 
             {/* Login / user indicator */}
@@ -251,7 +254,7 @@ const MainLayout: React.FC = () => {
                       <div className="px-3 py-2 text-sm font-medium text-muted-foreground uppercase tracking-wider">
                         Applications
                       </div>
-                      {subAppsData.applications.map((app) => {
+                      {visibleApps.map((app) => {
                         return (
                           <button
                             key={app.id}

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -68,23 +68,12 @@ const MainLayout: React.FC = () => {
 
   const navPadding = isScrolled ? "py-2" : "py-3 md:py-4";
 
-  const handleAppNavigation = async (app: {
-    slug: string;
-    url: string;
-    requires_auth: boolean;
-    is_external: boolean;
-  }) => {
-    if (!app.requires_auth) {
-      window.open(app.url, app.is_external ? "_blank" : "_self");
-      return;
-    }
-
-    try {
-      const { url } = await applications.getJumpUrl(app.slug, "app");
-      window.open(url, app.is_external ? "_blank" : "_self");
-    } catch (error) {
-      console.error("Failed to open application", error);
-    }
+  const handleAppNavigation = (app: { url: string; is_external: boolean }) => {
+    window.open(
+      app.url,
+      app.is_external ? "_blank" : "_self",
+      "noopener,noreferrer",
+    );
   };
 
   return (

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -175,20 +175,16 @@ const MainLayout: React.FC = () => {
             </nav>
 
             {/* Login / user indicator */}
-            <div className="hidden md:flex items-center">
-              {isAuthenticated ? (
-                <span className="text-sm text-muted-foreground">
-                  {/* Intentionally minimal — admin access is via /admin */}
-                </span>
-              ) : (
+            {!isAuthenticated && (
+              <div className="hidden md:flex items-center">
                 <a
                   href="/api/auth/login?next=/admin"
                   className={`px-3 transition-all duration-300 ease-out ${navPadding} ${navClasses} text-foreground hover:text-primary`}
                 >
                   Login
                 </a>
-              )}
-            </div>
+              </div>
+            )}
 
             {/* Mobile menu button */}
             <div className="md:hidden">

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -169,7 +169,7 @@ const MainLayout: React.FC = () => {
             {!isAuthenticated && (
               <div className="hidden md:flex items-center">
                 <a
-                  href="/api/auth/login?next=/admin"
+                  href={`/api/auth/login?next=${encodeURIComponent(location.pathname + location.search)}`}
                   className={`px-3 transition-all duration-300 ease-out ${navPadding} ${navClasses} text-foreground hover:text-primary`}
                 >
                   Login

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -29,9 +29,8 @@ const MainLayout: React.FC = () => {
   const isScrolled = scrollY > 10;
 
   const { data: subAppsData } = useQuery({
-    queryKey: ["applications", isAuthenticated ? "authenticated" : "public"],
-    queryFn: () =>
-      isAuthenticated ? applications.listAuthenticated() : applications.list(),
+    queryKey: ["applications", "public"],
+    queryFn: () => applications.list(),
   });
 
   // Fetch footer content

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { applications, content } from "../api/client";
 import { useAuthStore } from "../stores/authStore";
+import { useRef } from "react";
 
 const MainLayout: React.FC = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -31,6 +32,7 @@ const MainLayout: React.FC = () => {
   const { data: subAppsData } = useQuery({
     queryKey: ["applications", "public"],
     queryFn: () => applications.list(),
+    staleTime: 0,
   });
 
   const visibleApps = (subAppsData?.applications ?? []).filter(

--- a/frontend/src/pages/admin/AdminAppImport.tsx
+++ b/frontend/src/pages/admin/AdminAppImport.tsx
@@ -28,7 +28,6 @@ integration:
   admin_path: "/cookbook/admin"
   requires_auth: true
   admin_only: false
-  show_in_menu: true
   menu_order: 10
   has_admin: true
   admin_iframe: true

--- a/frontend/src/pages/admin/AdminApplications.tsx
+++ b/frontend/src/pages/admin/AdminApplications.tsx
@@ -30,6 +30,7 @@ interface AppFormData {
   is_external: boolean;
   requires_auth: boolean;
   admin_only: boolean;
+  logged_in_only: boolean;
   enabled: boolean;
 }
 

--- a/frontend/src/pages/admin/AdminApplications.tsx
+++ b/frontend/src/pages/admin/AdminApplications.tsx
@@ -9,9 +9,10 @@ import { Button } from "../../components/ui/button";
 import {
   useApplications,
   useCreateApplication,
-  useUpdateApplication,
   useDeleteApplication,
+  useReorderApplications,
   useToggleAppEnabled,
+  useUpdateApplication,
 } from "../../hooks/useApplications";
 import { applications as applicationsApi } from "../../api/client";
 import type { Application } from "../../types";
@@ -28,7 +29,6 @@ interface AppFormData {
   admin_only: boolean;
   show_in_menu: boolean;
   enabled: boolean;
-  order: number;
 }
 
 const AdminApplications: React.FC = () => {
@@ -48,6 +48,7 @@ const AdminApplications: React.FC = () => {
   const updateMutation = useUpdateApplication();
   const deleteMutation = useDeleteApplication();
   const toggleEnabledMutation = useToggleAppEnabled();
+  const reorderMutation = useReorderApplications();
 
   const apps = applicationsData?.applications ?? [];
 
@@ -103,6 +104,10 @@ const AdminApplications: React.FC = () => {
       // Error handling is done in the mutation hook
       console.error("Toggle enabled error:", error);
     }
+  };
+
+  const handleReorder = (items: Array<{ id: string; order: number }>) => {
+    reorderMutation.mutate(items);
   };
 
   const handleOpenApplication = async (
@@ -272,6 +277,7 @@ const AdminApplications: React.FC = () => {
           onToggleEnabled={(id, enabled) => {
             void handleToggleEnabled(id, enabled);
           }}
+          onReorder={handleReorder}
           isLoading={isLoadingApplications}
         />
       </div>

--- a/frontend/src/pages/admin/AdminApplications.tsx
+++ b/frontend/src/pages/admin/AdminApplications.tsx
@@ -17,7 +17,6 @@ import {
   useToggleAppEnabled,
   useUpdateApplication,
 } from "../../hooks/useApplications";
-import { applications as applicationsApi } from "../../api/client";
 import type { Application } from "../../types";
 
 interface AppFormData {
@@ -32,6 +31,7 @@ interface AppFormData {
   admin_only: boolean;
   logged_in_only: boolean;
   enabled: boolean;
+  redirect_uris?: string;
 }
 
 const AdminApplications: React.FC = () => {

--- a/frontend/src/pages/admin/AdminApplications.tsx
+++ b/frontend/src/pages/admin/AdminApplications.tsx
@@ -117,13 +117,19 @@ const AdminApplications: React.FC = () => {
     application: Application,
     target: "app" | "admin",
   ) => {
+    const windowTarget = application.is_external ? "_blank" : "_self";
     try {
       if (application.requires_auth) {
+        const win = window.open("", windowTarget);
         const { url } = await applicationsApi.getJumpUrl(
           application.slug,
           target,
         );
-        window.open(url, application.is_external ? "_blank" : "_self");
+        if (win) {
+          win.location.href = url;
+        } else {
+          window.open(url, windowTarget);
+        }
         return;
       }
 
@@ -131,7 +137,7 @@ const AdminApplications: React.FC = () => {
         target === "admin"
           ? (application.admin_url ?? application.url)
           : application.url;
-      window.open(destination, application.is_external ? "_blank" : "_self");
+      window.open(destination, windowTarget);
     } catch (error) {
       console.error("Open application error:", error);
     }

--- a/frontend/src/pages/admin/AdminApplications.tsx
+++ b/frontend/src/pages/admin/AdminApplications.tsx
@@ -113,32 +113,15 @@ const AdminApplications: React.FC = () => {
     reorderMutation.mutate(items);
   };
 
-  const handleOpenApplication = async (
+  const handleOpenApplication = (
     application: Application,
     target: "app" | "admin",
   ) => {
-    try {
-      if (application.requires_auth) {
-        const { url } = await applicationsApi.getJumpUrl(
-          application.slug,
-          target,
-        );
-        window.location.href = url;
-        return;
-      }
-
-      const destination =
-        target === "admin"
-          ? (application.admin_url ?? application.url)
-          : application.url;
-      if (application.is_external) {
-        window.open(destination, "_blank", "noopener,noreferrer");
-      } else {
-        window.location.href = destination;
-      }
-    } catch (error) {
-      console.error("Open application error:", error);
-    }
+    const destination =
+      target === "admin"
+        ? (application.admin_url ?? application.url)
+        : application.url;
+    window.open(destination, "_blank", "noopener,noreferrer");
   };
 
   const isFormLoading = createMutation.isPending || updateMutation.isPending;

--- a/frontend/src/pages/admin/AdminApplications.tsx
+++ b/frontend/src/pages/admin/AdminApplications.tsx
@@ -2,6 +2,8 @@ import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { Plus, FileCode2 } from "lucide-react";
+import { Switch } from "../../components/ui/switch";
+import { cn } from "../../lib/utils";
 
 import AppForm from "../../components/AppForm";
 import AppList from "../../components/AppList";
@@ -35,6 +37,7 @@ const AdminApplications: React.FC = () => {
   const [showForm, setShowForm] = useState(false);
   const [editingApplication, setEditingApplication] =
     useState<Application | null>(null);
+  const [reorderEnabled, setReorderEnabled] = useState(false);
 
   // Query hooks
   const {
@@ -166,26 +169,49 @@ const AdminApplications: React.FC = () => {
   return (
     <div>
       {/* Header */}
-      <div className="mb-10">
-        <div className="flex justify-between items-center">
-          <div className="space-y-3">
-            <h1 className="admin-page-title">Applications</h1>
-            <p className="text-muted-foreground text-xl">
+      <div className="mb-12">
+        <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between border-b pb-8">
+          <div className="space-y-2">
+            <h1 className="text-4xl font-extrabold tracking-tight bg-gradient-to-r from-foreground to-foreground/70 bg-clip-text text-transparent">
+              Applications
+            </h1>
+            <p className="text-muted-foreground text-lg">
               Manage external and internal applications
             </p>
           </div>
-          <div className="flex gap-3">
-            <Button variant="outline" asChild>
+
+          <div className="flex flex-wrap items-center gap-4">
+            <div className="flex items-center gap-3 bg-muted/30 px-4 py-2 rounded-xl border border-dashed border-border/60">
+              <span className="text-xs font-bold uppercase tracking-wider text-muted-foreground/80">
+                Reorder
+              </span>
+              <Switch
+                checked={reorderEnabled}
+                onCheckedChange={(checked) => {
+                  if (!apps.length && checked) return;
+                  setReorderEnabled(checked);
+                }}
+              />
+            </div>
+
+            <Button
+              variant="outline"
+              size="lg"
+              className={cn("rounded-full px-6")}
+              asChild
+            >
               <Link to="/admin/applications/import">
                 <FileCode2 className="h-4 w-4 mr-2" />
                 Import via YAML
               </Link>
             </Button>
+
             <Button
               variant="gradient"
               size="lg"
               onClick={() => handleCreateApplication()}
-              disabled={showForm}
+              disabled={showForm || reorderEnabled}
+              className="rounded-full px-8 shadow-xl shadow-primary/20"
             >
               <Plus className="h-5 w-5 mr-2" />
               Add Application
@@ -264,6 +290,7 @@ const AdminApplications: React.FC = () => {
 
         <AppList
           applications={apps}
+          reorderEnabled={reorderEnabled}
           onEdit={handleEditApplication}
           onOpen={(application) => {
             void handleOpenApplication(application, "app");

--- a/frontend/src/pages/admin/AdminApplications.tsx
+++ b/frontend/src/pages/admin/AdminApplications.tsx
@@ -117,19 +117,13 @@ const AdminApplications: React.FC = () => {
     application: Application,
     target: "app" | "admin",
   ) => {
-    const windowTarget = application.is_external ? "_blank" : "_self";
     try {
       if (application.requires_auth) {
-        const win = window.open("", windowTarget);
         const { url } = await applicationsApi.getJumpUrl(
           application.slug,
           target,
         );
-        if (win) {
-          win.location.href = url;
-        } else {
-          window.open(url, windowTarget);
-        }
+        window.location.href = url;
         return;
       }
 
@@ -137,7 +131,11 @@ const AdminApplications: React.FC = () => {
         target === "admin"
           ? (application.admin_url ?? application.url)
           : application.url;
-      window.open(destination, windowTarget);
+      if (application.is_external) {
+        window.open(destination, "_blank", "noopener,noreferrer");
+      } else {
+        window.location.href = destination;
+      }
     } catch (error) {
       console.error("Open application error:", error);
     }

--- a/frontend/src/pages/admin/AdminApplications.tsx
+++ b/frontend/src/pages/admin/AdminApplications.tsx
@@ -30,7 +30,6 @@ interface AppFormData {
   is_external: boolean;
   requires_auth: boolean;
   admin_only: boolean;
-  show_in_menu: boolean;
   enabled: boolean;
 }
 

--- a/frontend/src/pages/admin/AdminApplications.tsx
+++ b/frontend/src/pages/admin/AdminApplications.tsx
@@ -12,6 +12,7 @@ import {
   useApplications,
   useCreateApplication,
   useDeleteApplication,
+  useRegenerateCredentials,
   useReorderApplications,
   useToggleAppEnabled,
   useUpdateApplication,
@@ -52,6 +53,7 @@ const AdminApplications: React.FC = () => {
   const deleteMutation = useDeleteApplication();
   const toggleEnabledMutation = useToggleAppEnabled();
   const reorderMutation = useReorderApplications();
+  const regenerateCredentialsMutation = useRegenerateCredentials();
 
   const apps = applicationsData?.applications ?? [];
 
@@ -261,6 +263,14 @@ const AdminApplications: React.FC = () => {
                     await handleFormSubmit(data);
                   }}
                   onCancel={() => handleFormCancel()}
+                  onRegenerateCredentials={
+                    editingApplication
+                      ? () =>
+                          regenerateCredentialsMutation.mutate(
+                            editingApplication.id,
+                          )
+                      : undefined
+                  }
                   isLoading={isFormLoading}
                 />
               </div>

--- a/frontend/src/test/integration/api.test.ts
+++ b/frontend/src/test/integration/api.test.ts
@@ -566,7 +566,6 @@ describe("API Integration Tests", () => {
       url: "https://application.example.com",
       icon: "test-icon",
       enabled: true,
-      show_in_menu: true,
       requires_auth: false,
       is_external: true,
       admin_only: false,

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -128,6 +128,7 @@ export interface Application {
   is_external: boolean;
   requires_auth: boolean;
   admin_only: boolean;
+  logged_in_only: boolean;
   enabled: boolean;
   order: number;
   client_id?: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -128,7 +128,6 @@ export interface Application {
   is_external: boolean;
   requires_auth: boolean;
   admin_only: boolean;
-  show_in_menu: boolean;
   enabled: boolean;
   order: number;
   client_id?: string;


### PR DESCRIPTION
## Summary

- Redesigned admin applications list with compact cards, overflow menu, and drag-to-reorder (consistent with photos/projects)
- Added `POST /applications/{id}/regenerate-credentials` endpoint; credentials moved to edit form only
- Fixed credential leak: `client_id`/`client_secret` no longer returned on public API endpoints
- Fixed authelia not joining `first-party-auth-network` in dev compose
- Fixed pydantic UUID coercion and `setdefault` bug on app creation
- Added reorder toggle pill matching photos page style; grip handle animates in/out
- Login button now redirects back to current page instead of hardcoded `/admin`
- App URLs open directly in new tab from admin (no jump URL indirection)
- Fixed navbar apps not showing due to stale React Query cache

## Test plan

- [ ] Create an application with `requires_auth=true` — verify `client_id`/`client_secret` auto-generated
- [ ] Edit application — verify credentials visible with copy buttons and regenerate link works
- [ ] Confirm `GET /api/applications/` response contains no `client_id` or `client_secret`
- [ ] Toggle reorder mode on — drag apps to reorder, verify order persists after reload
- [ ] Click Open/Admin buttons — verify they open in a new tab
- [ ] Log out, click Login from homepage — verify redirect returns to same page
- [ ] Verify enabled apps appear in navbar Apps dropdown