### PR TITLE
Fix broken responsive image variants and add admin regeneration UI

### DIFF
--- a/backend/app/api/photos.py
+++ b/backend/app/api/photos.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import math
 import time
 import typing
 import uuid
 from datetime import datetime
+from pathlib import Path
 from uuid import UUID
 
+import pyvips
 from fastapi import (
     APIRouter,
     Form,
@@ -21,6 +24,7 @@ from fastapi.responses import FileResponse
 from sqlalchemy import and_, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import flag_modified
 
 from app.config import settings
 from app.core.file_access import file_access_controller
@@ -591,6 +595,115 @@ async def reorder_photos(
         items.append({"id": photo_id, "order": i.order})
     await bulk_reorder_photos(db, items, normalize=payload.normalize)
     return {"message": "Reordered successfully"}
+
+
+@router.post("/{photo_id}/regenerate-variants", response_model=PhotoResponse)
+async def regenerate_photo_variants(
+    photo_id: UUID,
+    request: Request,
+    size: str | None = Query(
+        None, description="Regenerate only this responsive size (e.g. 'thumbnail')"
+    ),
+    format: str | None = Query(  # noqa: A002
+        None, description="Regenerate only this format (e.g. 'webp')"
+    ),
+    db: AsyncSession = _session_dependency,
+    current_user: User = _current_superuser_dependency,
+) -> PhotoResponse:
+    """Regenerate responsive image variants for a photo (admin only).
+
+    With no query params, regenerates every responsive size/format from the
+    stored original. With `size` (and optionally `format`), regenerates only
+    that cell, merging the result into the existing `variants` JSON without
+    discarding other sizes/formats.
+    """
+    photo = await get_photo(db, photo_id)
+    if not photo:
+        raise HTTPException(status_code=404, detail="Photo not found")
+
+    original_path = (
+        Path(settings.upload_dir) / Path(photo.original_path).name
+    ).resolve()
+    if not original_path.is_file():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Original file not found: {photo.original_path}",
+        )
+
+    config_service = request.app.state.config_service
+    image_config = ImageVariantConfig(
+        responsive_sizes=config_service.responsive_sizes,
+        quality_settings=config_service.quality_settings,
+        avif_quality_base_offset=config_service.avif_quality_base_offset,
+        avif_quality_floor=config_service.avif_quality_floor,
+        avif_effort_default=config_service.avif_effort_default,
+    )
+    processor = VipsImageProcessor(
+        settings.upload_dir, settings.compressed_dir, image_config
+    )
+
+    if size is not None:
+        if size not in image_config.responsive_sizes:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unknown size '{size}'",
+            )
+        target_size = image_config.responsive_sizes[size]
+
+        def _regenerate_one() -> dict:
+            vips_image = pyvips.Image.new_from_file(str(original_path), access="random")
+            vips_image = vips_image.autorot()
+            if vips_image.interpretation != "srgb":
+                vips_image = vips_image.colourspace("srgb")
+            if target_size > max(vips_image.width, vips_image.height):
+                return {}
+            return processor.generate_variant_formats(
+                vips_image, str(photo_id), size, target_size
+            )
+
+        new_size_variants = await asyncio.to_thread(_regenerate_one)
+
+        existing_variants = dict(photo.variants or {})
+        existing_size_data = dict(existing_variants.get(size) or {})
+
+        if format is not None:
+            if format not in {"avif", "webp", "jpeg"}:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Unknown format '{format}'",
+                )
+            if format in new_size_variants:
+                existing_size_data[format] = new_size_variants[format]
+            else:
+                existing_size_data.pop(format, None)
+            existing_variants[size] = existing_size_data
+        else:
+            existing_variants[size] = new_size_variants
+
+        photo.variants = existing_variants
+    else:
+        new_variants = await asyncio.to_thread(
+            processor.generate_responsive_variants, original_path, str(photo_id)
+        )
+        existing_variants = dict(photo.variants or {})
+        existing_variants.update(new_variants)
+        photo.variants = existing_variants
+
+    flag_modified(photo, "variants")
+    await db.commit()
+    await db.refresh(photo)
+
+    alias_service = AliasService(db)
+    photo_dict = PhotoResponse.model_validate(photo).model_dump()
+    photo_dict["camera_display_name"] = await alias_service.get_camera_display_name(
+        getattr(photo, "camera_make", None), getattr(photo, "camera_model", None)
+    )
+    photo_dict["lens_display_name"] = await alias_service.get_lens_display_name(
+        getattr(photo, "lens", None)
+    )
+    photo_dict = populate_photo_urls(photo_dict, str(photo.id))
+
+    return PhotoResponse.model_validate(photo_dict)
 
 
 @router.get("/stats/summary")

--- a/backend/app/core/vips_processor.py
+++ b/backend/app/core/vips_processor.py
@@ -282,9 +282,10 @@ class VipsImageProcessor:
     def _generate_responsive_variants(self, original_path: Path, file_id: str) -> dict:
         """Generate multiple responsive image sizes in AVIF, WebP, and JPEG formats."""
         try:
-            vips_image = pyvips.Image.new_from_file(
-                str(original_path), access="sequential"
-            )
+            # access="random" decodes the source into memory once so each
+            # responsive size can independently re-read pixels; "sequential"
+            # only supports a single pass and breaks on the second resize.
+            vips_image = pyvips.Image.new_from_file(str(original_path), access="random")
             return self._build_vips_variants(vips_image, file_id)
         except Exception:
             logger.exception("Error generating responsive variants")

--- a/backend/app/core/vips_processor.py
+++ b/backend/app/core/vips_processor.py
@@ -145,7 +145,7 @@ class VipsImageProcessor:
 
         # Generate all responsive sizes with multiple formats
         variants = await asyncio.to_thread(
-            self._generate_responsive_variants, original_path, file_id
+            self.generate_responsive_variants, original_path, file_id
         )
 
         self._update_progress("complete", 100)
@@ -229,7 +229,7 @@ class VipsImageProcessor:
             "mime_type": "image/jpeg",
         }
 
-    def _generate_variant_formats(
+    def generate_variant_formats(
         self,
         vips_image: pyvips.Image,
         file_id: str,
@@ -271,7 +271,7 @@ class VipsImageProcessor:
         for size_name, target_size in self.config.responsive_sizes.items():
             if target_size > max(original_width, original_height):
                 continue
-            variants[size_name] = self._generate_variant_formats(
+            variants[size_name] = self.generate_variant_formats(
                 vips_image, file_id, size_name, target_size
             )
             current_progress += progress_per_variant
@@ -279,7 +279,7 @@ class VipsImageProcessor:
 
         return variants
 
-    def _generate_responsive_variants(self, original_path: Path, file_id: str) -> dict:
+    def generate_responsive_variants(self, original_path: Path, file_id: str) -> dict:
         """Generate multiple responsive image sizes in AVIF, WebP, and JPEG formats."""
         try:
             # access="random" decodes the source into memory once so each

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,7 +52,29 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libjpeg62-turbo-dev \
     nginx \
     supervisor \
+    cmake \
+    git \
     && rm -rf /var/lib/apt/lists/*
+
+# Build and install the libheif AOM (AV1) encoder plugin for AVIF support.
+# Debian's libheif packages only ship decoder plugins (dav1d, libde265);
+# there is no packaged AVIF encoder plugin, so heifsave() fails with
+# "Unsupported compression". Build the plugin from source against the
+# headers/lib of whatever libheif-dev apt just installed, so the plugin
+# ABI always matches the system libheif.so.1 (not pinned to a fixed tag,
+# since apt may pull a newer libheif-dev on rebuild).
+# hadolint ignore=DL3003
+RUN git clone --branch "v$(pkg-config --modversion libheif)" --depth 1 https://github.com/strukturag/libheif.git /tmp/libheif && \
+    cmake -S /tmp/libheif -B /tmp/libheif/build \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DWITH_AOM_ENCODER=ON -DWITH_AOM_ENCODER_PLUGIN=ON \
+          -DWITH_X265=ON -DWITH_X265_PLUGIN=ON \
+          -DENABLE_PLUGIN_LOADING=ON \
+          -DPLUGIN_DIRECTORY=/usr/lib/"$(gcc -dumpmachine)"/libheif/plugins \
+          -DBUILD_TESTING=OFF -DWITH_EXAMPLES=OFF && \
+    cmake --build /tmp/libheif/build -j"$(nproc)" && \
+    cmake --install /tmp/libheif/build && \
+    rm -rf /tmp/libheif
 
 # Stage 3: final production image
 FROM python-base AS final

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,6 +53,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     nginx \
     supervisor \
     cmake \
+    make \
     git \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -50,7 +50,7 @@ RUN git clone --branch "v$(pkg-config --modversion libheif)" --depth 1 https://g
           -DWITH_AOM_ENCODER=ON -DWITH_AOM_ENCODER_PLUGIN=ON \
           -DWITH_X265=ON -DWITH_X265_PLUGIN=ON \
           -DENABLE_PLUGIN_LOADING=ON \
-          -DPLUGIN_DIRECTORY=/usr/lib/aarch64-linux-gnu/libheif/plugins \
+          -DPLUGIN_DIRECTORY=/usr/lib/"$(gcc -dumpmachine)"/libheif/plugins \
           -DBUILD_TESTING=OFF -DWITH_EXAMPLES=OFF && \
     cmake --build /tmp/libheif/build -j"$(nproc)" && \
     cmake --install /tmp/libheif/build && \

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -33,7 +33,26 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libpango1.0-dev \
     libgif-dev \
     make \
+    cmake \
     && rm -rf /var/lib/apt/lists/*
+
+# Build and install the libheif AOM (AV1) encoder plugin for AVIF support.
+# Debian's libheif packages only ship decoder plugins (dav1d, libde265);
+# there is no packaged AVIF encoder plugin, so heifsave() fails with
+# "Unsupported compression". Build the plugin from source against the
+# system libheif 1.19.8 headers/lib and drop it into libheif's plugin dir.
+# hadolint ignore=DL3003
+RUN git clone --branch v1.19.8 --depth 1 https://github.com/strukturag/libheif.git /tmp/libheif && \
+    cmake -S /tmp/libheif -B /tmp/libheif/build \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DWITH_AOM_ENCODER=ON -DWITH_AOM_ENCODER_PLUGIN=ON \
+          -DWITH_X265=ON -DWITH_X265_PLUGIN=ON \
+          -DENABLE_PLUGIN_LOADING=ON \
+          -DPLUGIN_DIRECTORY=/usr/lib/aarch64-linux-gnu/libheif/plugins \
+          -DBUILD_TESTING=OFF -DWITH_EXAMPLES=OFF && \
+    cmake --build /tmp/libheif/build -j"$(nproc)" && \
+    cmake --install /tmp/libheif/build && \
+    rm -rf /tmp/libheif
 
 # Install Python dependencies (including test deps for dev)
 COPY backend/pyproject.toml /app/backend/

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -40,9 +40,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # Debian's libheif packages only ship decoder plugins (dav1d, libde265);
 # there is no packaged AVIF encoder plugin, so heifsave() fails with
 # "Unsupported compression". Build the plugin from source against the
-# system libheif 1.19.8 headers/lib and drop it into libheif's plugin dir.
+# headers/lib of whatever libheif-dev apt just installed, so the plugin
+# ABI always matches the system libheif.so.1 (not pinned to a fixed tag,
+# since apt may pull a newer libheif-dev on rebuild).
 # hadolint ignore=DL3003
-RUN git clone --branch v1.19.8 --depth 1 https://github.com/strukturag/libheif.git /tmp/libheif && \
+RUN git clone --branch "v$(pkg-config --modversion libheif)" --depth 1 https://github.com/strukturag/libheif.git /tmp/libheif && \
     cmake -S /tmp/libheif -B /tmp/libheif/build \
           -DCMAKE_BUILD_TYPE=Release \
           -DWITH_AOM_ENCODER=ON -DWITH_AOM_ENCODER_PLUGIN=ON \

--- a/docs/IMAGE_VARIANT_BUG.md
+++ b/docs/IMAGE_VARIANT_BUG.md
@@ -1,0 +1,152 @@
+# Image variant generation bug
+
+## Symptom
+
+Photo grid (`PhotoGrid`) and map thumbnails (`MapLibrePhotoMap`) take several seconds
+to load even with only 2-3 photos, in both dev and staging. Suspected cause: frontend
+falling back to serving original multi-MB JPEGs instead of WebP variants.
+
+## Root cause #1 (the urgent one): sequential-access pyvips pipeline reused across variants
+
+File: `backend/app/core/vips_processor.py`
+
+`_generate_responsive_variants` / `_build_vips_variants` loads the source image once
+with `pyvips.Image.new_from_file(path, access="sequential")`, then calls `.resize()`
+on that **same** image object once per target size (micro, thumbnail, small, medium,
+large, xlarge), generating avif/webp/jpeg for each.
+
+A `sequential`-access vips pipeline can only be read once, scanline by scanline. The
+first resize+save (micro) consumes the read. Every subsequent `.resize()` derived from
+the same source object then fails silently (caught by broad `except Exception` in
+`_save_*_variant`, logged, returns `None`).
+
+**Result for every real upload**: only `micro` gets a working `webp` variant.
+`thumbnail`, `small`, `medium`, `large`, `xlarge` all end up as empty `{}` dicts in the
+`variants` JSON column. Even micro's avif/jpeg fail too, since they're attempted after
+webp has already partially drained the pipeline.
+
+Confirmed live via direct repro inside `portfolio-app-dev`:
+
+```python
+img = pyvips.Image.new_from_file(src, access="sequential").autorot().colourspace("srgb")
+r1 = img.resize(64/4000, kernel="lanczos3")
+r1.webpsave("/tmp/micro.webp", Q=50, effort=6)   # OK
+r2 = img.resize(150/4000, kernel="lanczos3")
+r2.webpsave("/tmp/thumb.webp", Q=60, effort=6)   # FAIL: unable to call webpsave (empty libvips error)
+```
+
+This matches the live DB state for all 3 existing photo rows: `variants.thumbnail/small/
+medium/large/xlarge == {}`, `variants.micro.webp` present and valid.
+
+### Downstream effect on frontend
+
+- `PhotoGrid.tsx` -> `selectOptimalImage` (`frontend/src/utils/imageUtils.ts:307-346`)
+  picks the smallest-fitting variant by width, falling back to `photo.original_url`
+  if `variants[selectedVariant]?.url` is missing.
+- `MapLibrePhotoMap.tsx:107-109` requests `variants["thumbnail"]?.url ?? variants["small"]?.url`,
+  also falling back to `original_url`.
+- Since thumbnail/small/medium/large/xlarge are all empty, both components fall back to
+  the full-size original JPEG (multi-MB) — the actual cause of the slow grid/map loads.
+
+### Fix direction (not yet implemented)
+
+Load the source image with `access="random"` (full in-memory random access) instead of
+`"sequential"` in `_generate_responsive_variants`. We deliberately need to re-derive
+pixels 6 times (once per target size: micro/thumbnail/small/medium/large/xlarge) from
+the same source — `sequential` access is a streaming optimization for single-pass
+consumption and breaks once a second `.resize()` is derived from the same source
+object. `random` decodes once into memory and allows repeated independent reads;
+reloading from disk per-size with `sequential` would also work but costs 6x JPEG
+decode. Keep the existing per-format try/except-and-continue behavior in
+`_save_avif_variant`/`_save_webp_variant`/`_save_jpeg_variant` as-is — that resilience
+is correct and orthogonal to this bug.
+
+After the code fix, existing photos in the DB still have empty variant dicts and need a
+backfill: re-run `_generate_responsive_variants` against their original files and update
+the `variants` column.
+
+### Open follow-up: surface processing errors to the frontend
+
+Right now, when a variant format fails to generate, the failure is only logged
+server-side (`logger.exception(...)` in `_save_*_variant`) and silently produces an
+empty `{}` for that size/format in the `variants` JSON. `populate_photo_urls`
+(`backend/app/api/photos.py` ~268-288) does detect entirely-empty size dicts and
+attaches a `processing_errors` list to the API response, but:
+
+- It's not clear the frontend (admin UI in particular) surfaces `processing_errors`
+  anywhere visibly — an admin uploading a photo with broken variant generation
+  currently has no indication anything went wrong.
+- Once the sequential-access bug above is fixed, *legitimate* per-format failures
+  (e.g. AVIF due to root cause #2) should still be visible to admins so they're aware
+  a photo is serving degraded variants.
+
+Needs a follow-up: surface `processing_errors` (or a similar signal) in the admin
+photos UI (e.g. `AdminPhotos.tsx` / `PhotoForm.tsx`) so broken variant generation is
+visible and actionable, rather than only discoverable by inspecting slow page loads or
+backend logs.
+
+### Open follow-up: frontend variant table + per-size regenerate
+
+Add a "Variants" section to `PhotoForm.tsx` (the admin photo editor) showing a table
+of all responsive sizes (micro/thumbnail/small/medium/large/xlarge) x formats
+(webp/jpeg/avif), with a checkmark/status indicator per cell (present / missing /
+errored).
+
+- Each present cell should show the compressed file size (`size_bytes` from the
+  `variants` JSON, e.g. "546 B" / "19.2 KB"), in addition to the checkmark. The
+  original file size (`photo.file_size`) should also be shown somewhere in the
+  table (e.g. a header row or alongside the size label) so admins can see the
+  compression ratio at a glance.
+- Missing or errored cells should be visually distinct (e.g. an empty/red state vs a
+  green checkmark for present variants).
+- On hover over a cell (or its checkmark), it should turn into a "Regenerate" action.
+  Clicking it triggers a backend endpoint that re-runs `_generate_responsive_variants`
+  (or a single-size/format variant of it) for that photo, writes the result back into
+  the `variants` JSON column, and the table should refresh immediately to reflect the
+  new state (success or renewed failure).
+- This doubles as the backfill mechanism for the existing photos affected by root
+  cause #1 (empty thumbnail/small/medium/large/xlarge) — instead of (or in addition
+  to) a one-off bulk backfill script, admins can regenerate per-photo from the UI.
+- Needs a new backend endpoint, e.g. `POST /api/photos/{id}/regenerate-variants`
+  (optionally with a `size`/`format` filter for single-cell regeneration), reusing
+  `VipsImageProcessor`/`_generate_responsive_variants` against the photo's stored
+  original file.
+
+## Root cause #2 (separate, lower priority): AVIF/HEIF encoding structurally broken
+
+File: `backend/app/core/vips_processor.py`, `_save_avif_variant` (heifsave).
+
+- The `vips-heif.so` loadable module **does** exist and loads successfully
+  (`/usr/lib/aarch64-linux-gnu/vips-modules-8.16/vips-heif.so`, links against
+  `libheif.so.1`). The earlier `ldd libvips.so` check showing no heif link was a red
+  herring — vips loads format modules via dlopen at runtime, not static linking.
+- However `heifsave` fails with **"Unsupported compression"** for every compression
+  value (av1, hevc, jpeg) because **libheif has zero encoder plugins installed**.
+- Debian only packages decoder-side libheif plugins:
+  - `libheif-plugin-dav1d` (AV1 decode only)
+  - `libheif-plugin-libde265` (HEVC decode only)
+- There is **no Debian package** providing `libheif-plugin-aom` (AV1 encode via
+  libaom) or `libheif-plugin-x265` (HEVC encode) for trixie/bookworm. Installing
+  `libaom-dev`/`libaom3` (already done in `docker/Dockerfile.dev`) doesn't help — there's
+  no packaged glue connecting libheif to libaom for encoding.
+- `apt-get install libheif1-plugin-aom` / `libheif1-plugin-hevc` (encoder variants) do
+  not exist as installable packages.
+
+### Fix direction (not yet implemented, lower priority)
+
+- (a) Build libheif's aom/x265 encoder plugins from source and drop the resulting
+  `.so` into libheif's plugin directory (`/usr/lib/aarch64-linux-gnu/libheif/plugins/`
+  or similar) — does not require rebuilding libvips itself, just the libheif plugin.
+- (b) Switch to a different base image/distro that packages encoder plugins.
+- (c) Build libheif from source with `--enable-encoder-aom` / `--enable-encoder-x265`.
+- Or: drop AVIF from the variant pipeline entirely and rely on WebP + JPEG fallback.
+
+## Separate issue noticed along the way (not yet fixed)
+
+`frontend/src/hooks/usePhotos.ts`: `useUpdatePhoto`, `useTogglePhotoFeatured`, and
+`useDeletePhoto` update/invalidate TanStack Query's `photoKeys` cache on success, but
+never call `usePhotoCacheStore.getState().updatePhoto(...)` /
+`.removePhoto(...)` (`frontend/src/stores/photoCache.ts`). `PhotographyPage.tsx` reads
+from this separate persisted Zustand store via `useOptimizedPhotos`, so admin edits
+(e.g. adding a location) don't show up there until the store's 5-minute
+`CACHE_MAX_AGE` expires.

--- a/docs/IMAGE_VARIANT_BUG.md
+++ b/docs/IMAGE_VARIANT_BUG.md
@@ -112,6 +112,29 @@ errored).
   `VipsImageProcessor`/`_generate_responsive_variants` against the photo's stored
   original file.
 
+#### Implementation plan
+
+1. **Backend**: `POST /api/photos/{id}/regenerate-variants` (optional `size`/`format`
+   query params), reuses `VipsImageProcessor._generate_responsive_variants` against
+   the photo's original file, merges results into `variants` JSON, returns updated
+   `PhotoResponse`.
+2. **API client**: add `photos.regenerateVariants(id, { size?, format? })`.
+3. **Hook**: `useRegenerateVariants()` mutation in `usePhotos.ts` — on success, merge
+   returned `variants`/`processing_errors` into `photoKeys.detail(id)` and
+   `photoKeys.list("admin-order")` caches, sync to `usePhotoCacheStore`, toast on
+   success/failure.
+4. **New component** `frontend/src/components/admin/PhotoVariantsTable.tsx` — rows =
+   sizes, columns = formats, each cell shows checkmark + `size_bytes` (formatted via
+   `formatFileSize`) or missing/error state; hover swaps to "Regenerate"; shows
+   `photo.file_size` (original) for comparison; shows `processing_errors` as a
+   warning banner.
+5. **Wire into `PhotoForm.tsx`**: render `<PhotoVariantsTable photo={photo} />` inside
+   the left preview panel (`md:col-span-1` sticky card, lines 249-412), placed after
+   the "Equipment Selection" block (after line 409) as its own `pt-2 border-t`
+   section — not as a new section in the main form fields column.
+6. Manual test: open a photo with missing variants, confirm table shows correct
+   status/sizes, regenerate a missing/errored cell, confirm immediate refresh.
+
 ## Root cause #2 (separate, lower priority): AVIF/HEIF encoding structurally broken
 
 File: `backend/app/core/vips_processor.py`, `_save_avif_variant` (heifsave).

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -330,6 +330,18 @@ export const photos = {
     );
     return response.data;
   },
+
+  regenerateVariants: async (
+    id: string,
+    params?: { size?: string; format?: string },
+  ): Promise<Photo> => {
+    const response = await apiClient.post<Photo>(
+      `/photos/${id}/regenerate-variants`,
+      undefined,
+      { params },
+    );
+    return response.data;
+  },
 };
 
 // Projects API

--- a/frontend/src/components/admin/PhotoForm.tsx
+++ b/frontend/src/components/admin/PhotoForm.tsx
@@ -409,6 +409,8 @@ const PhotoForm: React.FC<PhotoFormProps> = ({
                   </div>
                 </div>
 
+                <div className="mt-4" />
+
                 <PhotoVariantsTable photo={photo} />
               </div>
             </div>

--- a/frontend/src/components/admin/PhotoForm.tsx
+++ b/frontend/src/components/admin/PhotoForm.tsx
@@ -17,6 +17,7 @@ import { Trash2, Star, X, Check } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { useCameraAliases } from "../../hooks/useCameraAliases";
 import { useLensAliases } from "../../hooks/useLensAliases";
+import PhotoVariantsTable from "./PhotoVariantsTable";
 // Remove direct import of MapPicker and lazy-load it instead
 const LazyMapPicker = lazy(() => import("../MapPicker"));
 
@@ -407,6 +408,8 @@ const PhotoForm: React.FC<PhotoFormProps> = ({
                     </select>
                   </div>
                 </div>
+
+                <PhotoVariantsTable photo={photo} />
               </div>
             </div>
           </div>

--- a/frontend/src/components/admin/PhotoVariantsTable.tsx
+++ b/frontend/src/components/admin/PhotoVariantsTable.tsx
@@ -1,0 +1,149 @@
+import { useState } from "react";
+import { Check, X, RefreshCcw, Loader2, AlertTriangle } from "lucide-react";
+import type { Photo, ImageVariant, MultiFormatVariants } from "../../types";
+import { formatFileSize } from "../../utils/photoUtils";
+import { useRegenerateVariants } from "../../hooks/usePhotos";
+import { cn } from "../../lib/utils";
+
+const SIZES = [
+  "micro",
+  "thumbnail",
+  "small",
+  "medium",
+  "large",
+  "xlarge",
+] as const;
+
+const FORMATS = ["webp", "jpeg", "avif"] as const;
+
+interface PhotoVariantsTableProps {
+  photo: Photo;
+}
+
+const isImageVariant = (value: unknown): value is ImageVariant =>
+  !!value && typeof value === "object" && "size_bytes" in value;
+
+const getVariant = (
+  variants: Photo["variants"],
+  size: string,
+  format: "avif" | "webp" | "jpeg",
+): ImageVariant | undefined => {
+  const sizeData = variants?.[size];
+  if (!sizeData) return undefined;
+  const formatData = (sizeData as MultiFormatVariants)[format];
+  return isImageVariant(formatData) ? formatData : undefined;
+};
+
+export default function PhotoVariantsTable({ photo }: PhotoVariantsTableProps) {
+  const [pendingCell, setPendingCell] = useState<string | null>(null);
+  const regenerateVariants = useRegenerateVariants();
+
+  const handleRegenerate = (size: string, format: string) => {
+    const cellKey = `${size}-${format}`;
+    setPendingCell(cellKey);
+    regenerateVariants.mutate(
+      { id: photo.id, size, format },
+      {
+        onSettled: () => setPendingCell(null),
+      },
+    );
+  };
+
+  return (
+    <div className="pt-2 border-t border-border/40 space-y-2">
+      <div className="flex justify-between items-center">
+        <span className="font-semibold text-foreground/70 uppercase tracking-tight text-[10px]">
+          Variants
+        </span>
+        <span className="text-xs text-muted-foreground">
+          Original: {formatFileSize(photo.file_size)}
+        </span>
+      </div>
+
+      {photo.processing_errors && photo.processing_errors.length > 0 && (
+        <div className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-2 py-1.5 text-[11px] text-destructive">
+          <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+          <ul className="space-y-0.5">
+            {photo.processing_errors.map((err) => (
+              <li key={err}>{err}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-[11px] border-collapse">
+          <thead>
+            <tr>
+              <th className="text-left font-semibold text-foreground/70 uppercase tracking-tight text-[10px] py-1 pr-2">
+                Size
+              </th>
+              {FORMATS.map((format) => (
+                <th
+                  key={format}
+                  className="text-center font-semibold text-foreground/70 uppercase tracking-tight text-[10px] py-1 px-1"
+                >
+                  {format}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {SIZES.map((size) => (
+              <tr key={size} className="border-t border-border/20">
+                <td className="py-1 pr-2 font-medium capitalize">{size}</td>
+                {FORMATS.map((format) => {
+                  const cellKey = `${size}-${format}`;
+                  const variant = getVariant(photo.variants, size, format);
+                  const isPending =
+                    pendingCell === cellKey && regenerateVariants.isPending;
+
+                  return (
+                    <td key={format} className="py-1 px-1 text-center">
+                      <div
+                        className={cn(
+                          "group relative flex items-center justify-center rounded-md px-1.5 py-1 min-h-[22px]",
+                          variant
+                            ? "bg-emerald-500/10 text-emerald-600"
+                            : "bg-destructive/10 text-destructive",
+                        )}
+                      >
+                        {isPending ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <>
+                            <span className="flex items-center gap-1 group-hover:opacity-0 transition-opacity">
+                              {variant ? (
+                                <>
+                                  <Check className="h-3 w-3" />
+                                  <span>
+                                    {formatFileSize(variant.size_bytes)}
+                                  </span>
+                                </>
+                              ) : (
+                                <X className="h-3 w-3" />
+                              )}
+                            </span>
+                            <button
+                              type="button"
+                              onClick={() => handleRegenerate(size, format)}
+                              title={`Regenerate ${size} ${format}`}
+                              aria-label={`Regenerate ${size} ${format}`}
+                              className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity rounded-md hover:bg-foreground/10"
+                            >
+                              <RefreshCcw className="h-3.5 w-3.5" />
+                            </button>
+                          </>
+                        )}
+                      </div>
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/PhotoVariantsTable.tsx
+++ b/frontend/src/components/admin/PhotoVariantsTable.tsx
@@ -35,16 +35,22 @@ const getVariant = (
 };
 
 export default function PhotoVariantsTable({ photo }: PhotoVariantsTableProps) {
-  const [pendingCell, setPendingCell] = useState<string | null>(null);
+  const [pendingCells, setPendingCells] = useState<Set<string>>(new Set());
   const regenerateVariants = useRegenerateVariants();
 
   const handleRegenerate = (size: string, format: string) => {
     const cellKey = `${size}-${format}`;
-    setPendingCell(cellKey);
+    setPendingCells((prev) => new Set(prev).add(cellKey));
     regenerateVariants.mutate(
       { id: photo.id, size, format },
       {
-        onSettled: () => setPendingCell(null),
+        onSettled: () => {
+          setPendingCells((prev) => {
+            const next = new Set(prev);
+            next.delete(cellKey);
+            return next;
+          });
+        },
       },
     );
   };
@@ -75,13 +81,13 @@ export default function PhotoVariantsTable({ photo }: PhotoVariantsTableProps) {
         <table className="w-full text-[11px] border-collapse">
           <thead>
             <tr>
-              <th className="text-left font-semibold text-foreground/70 uppercase tracking-tight text-[10px] py-1 pr-2">
+              <th className="w-[22%] text-left font-semibold text-foreground/70 uppercase tracking-tight text-[10px] py-1 pr-2">
                 Size
               </th>
               {FORMATS.map((format) => (
                 <th
                   key={format}
-                  className="text-center font-semibold text-foreground/70 uppercase tracking-tight text-[10px] py-1 px-1"
+                  className="w-[26%] text-center font-semibold text-foreground/70 uppercase tracking-tight text-[10px] py-1 px-1"
                 >
                   {format}
                 </th>
@@ -89,58 +95,75 @@ export default function PhotoVariantsTable({ photo }: PhotoVariantsTableProps) {
             </tr>
           </thead>
           <tbody>
-            {SIZES.map((size) => (
-              <tr key={size} className="border-t border-border/20">
-                <td className="py-1 pr-2 font-medium capitalize">{size}</td>
-                {FORMATS.map((format) => {
-                  const cellKey = `${size}-${format}`;
-                  const variant = getVariant(photo.variants, size, format);
-                  const isPending =
-                    pendingCell === cellKey && regenerateVariants.isPending;
+            {SIZES.map((size) => {
+              const referenceVariant =
+                getVariant(photo.variants, size, "webp") ??
+                getVariant(photo.variants, size, "jpeg") ??
+                getVariant(photo.variants, size, "avif");
+              const resolutionLabel = referenceVariant
+                ? `${referenceVariant.width} × ${referenceVariant.height}`
+                : undefined;
 
-                  return (
-                    <td key={format} className="py-1 px-1 text-center">
-                      <div
-                        className={cn(
-                          "group relative flex items-center justify-center rounded-md px-1.5 py-1 min-h-[22px]",
-                          variant
-                            ? "bg-emerald-500/10 text-emerald-600"
-                            : "bg-destructive/10 text-destructive",
-                        )}
+              return (
+                <tr key={size} className="border-t border-border/20">
+                  <td
+                    className="py-1 pr-2 font-medium capitalize"
+                    title={resolutionLabel}
+                  >
+                    {size}
+                  </td>
+                  {FORMATS.map((format) => {
+                    const cellKey = `${size}-${format}`;
+                    const variant = getVariant(photo.variants, size, format);
+                    const isPending = pendingCells.has(cellKey);
+
+                    return (
+                      <td
+                        key={format}
+                        className="w-[26%] py-1 px-1 text-center"
                       >
-                        {isPending ? (
-                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                        ) : (
-                          <>
-                            <span className="flex items-center gap-1 group-hover:opacity-0 transition-opacity">
-                              {variant ? (
-                                <>
-                                  <Check className="h-3 w-3" />
-                                  <span>
-                                    {formatFileSize(variant.size_bytes)}
-                                  </span>
-                                </>
-                              ) : (
-                                <X className="h-3 w-3" />
-                              )}
-                            </span>
-                            <button
-                              type="button"
-                              onClick={() => handleRegenerate(size, format)}
-                              title={`Regenerate ${size} ${format}`}
-                              aria-label={`Regenerate ${size} ${format}`}
-                              className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity rounded-md hover:bg-foreground/10"
-                            >
-                              <RefreshCcw className="h-3.5 w-3.5" />
-                            </button>
-                          </>
-                        )}
-                      </div>
-                    </td>
-                  );
-                })}
-              </tr>
-            ))}
+                        <div
+                          className={cn(
+                            "group relative flex items-center justify-center rounded-md px-1.5 py-1 min-h-[22px]",
+                            variant
+                              ? "bg-emerald-500/10 text-emerald-600"
+                              : "bg-destructive/10 text-destructive",
+                          )}
+                        >
+                          {isPending ? (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                          ) : (
+                            <>
+                              <span className="absolute inset-0 flex items-center justify-center gap-1 whitespace-nowrap transition-opacity duration-150 group-hover:opacity-0">
+                                {variant ? (
+                                  <>
+                                    <Check className="h-3 w-3 shrink-0" />
+                                    <span>
+                                      {formatFileSize(variant.size_bytes)}
+                                    </span>
+                                  </>
+                                ) : (
+                                  <X className="h-3 w-3" />
+                                )}
+                              </span>
+                              <button
+                                type="button"
+                                onClick={() => handleRegenerate(size, format)}
+                                title={`Regenerate ${size} ${format}`}
+                                aria-label={`Regenerate ${size} ${format}`}
+                                className="absolute inset-0 flex items-center justify-center rounded-md opacity-0 transition-opacity duration-150 hover:bg-foreground/10 group-hover:opacity-100"
+                              >
+                                <RefreshCcw className="h-3.5 w-3.5" />
+                              </button>
+                            </>
+                          )}
+                        </div>
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/frontend/src/components/admin/PhotoVariantsTable.tsx
+++ b/frontend/src/components/admin/PhotoVariantsTable.tsx
@@ -4,6 +4,7 @@ import type { Photo, ImageVariant, MultiFormatVariants } from "../../types";
 import { formatFileSize } from "../../utils/photoUtils";
 import { useRegenerateVariants } from "../../hooks/usePhotos";
 import { cn } from "../../lib/utils";
+import toast from "react-hot-toast";
 
 const SIZES = [
   "micro",
@@ -36,6 +37,7 @@ const getVariant = (
 
 export default function PhotoVariantsTable({ photo }: PhotoVariantsTableProps) {
   const [pendingCells, setPendingCells] = useState<Set<string>>(new Set());
+  const [isRegeneratingAll, setIsRegeneratingAll] = useState(false);
   const regenerateVariants = useRegenerateVariants();
 
   const handleRegenerate = (size: string, format: string) => {
@@ -55,15 +57,64 @@ export default function PhotoVariantsTable({ photo }: PhotoVariantsTableProps) {
     );
   };
 
+  const handleRegenerateAll = async () => {
+    setIsRegeneratingAll(true);
+    let failures = 0;
+
+    for (const size of SIZES) {
+      for (const format of FORMATS) {
+        const cellKey = `${size}-${format}`;
+        setPendingCells((prev) => new Set(prev).add(cellKey));
+        try {
+          await regenerateVariants.mutateAsync({
+            id: photo.id,
+            size,
+            format,
+            silent: true,
+          });
+        } catch {
+          failures += 1;
+        } finally {
+          setPendingCells((prev) => {
+            const next = new Set(prev);
+            next.delete(cellKey);
+            return next;
+          });
+        }
+      }
+    }
+
+    setIsRegeneratingAll(false);
+    if (failures > 0) {
+      toast.error(`Regenerated all variants, ${failures} failed.`);
+    } else {
+      toast.success("Regenerated all variants!");
+    }
+  };
+
   return (
     <div className="pt-2 border-t border-border/40 space-y-2">
       <div className="flex justify-between items-center">
         <span className="font-semibold text-foreground/70 uppercase tracking-tight text-[10px]">
           Variants
         </span>
-        <span className="text-xs text-muted-foreground">
-          Original: {formatFileSize(photo.file_size)}
-        </span>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">
+            Original: {formatFileSize(photo.file_size)}
+          </span>
+          <button
+            type="button"
+            onClick={() => void handleRegenerateAll()}
+            disabled={isRegeneratingAll}
+            title="Regenerate all variants"
+            className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-tight text-foreground/70 transition-colors hover:bg-foreground/10 hover:text-foreground disabled:opacity-50"
+          >
+            <RefreshCcw
+              className={cn("h-3 w-3", isRegeneratingAll && "animate-spin")}
+            />
+            All
+          </button>
+        </div>
       </div>
 
       {photo.processing_errors && photo.processing_errors.length > 0 && (

--- a/frontend/src/hooks/usePhotos.ts
+++ b/frontend/src/hooks/usePhotos.ts
@@ -553,6 +553,39 @@ export const useTogglePhotoFeatured = () => {
   });
 };
 
+// Hook to regenerate responsive image variants for a photo (optionally a single cell)
+export const useRegenerateVariants = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      id,
+      size,
+      format,
+    }: {
+      id: string;
+      size?: string;
+      format?: string;
+    }) => photos.regenerateVariants(id, { size, format }),
+
+    onError: () => {
+      toast.error("Failed to regenerate variants. Please try again.");
+    },
+
+    onSuccess: (updatedPhoto) => {
+      void queryClient.invalidateQueries({ queryKey: photoKeys.lists() });
+      void queryClient.invalidateQueries({
+        queryKey: photoKeys.detail(updatedPhoto.id),
+      });
+      void queryClient.invalidateQueries({ queryKey: photoKeys.stats() });
+
+      usePhotoCacheStore.getState().updatePhoto(updatedPhoto.id, updatedPhoto);
+
+      toast.success("Variants regenerated!");
+    },
+  });
+};
+
 // Hook to reorder photos
 export const useReorderPhotos = () => {
   const queryClient = useQueryClient();

--- a/frontend/src/hooks/usePhotos.ts
+++ b/frontend/src/hooks/usePhotos.ts
@@ -566,13 +566,15 @@ export const useRegenerateVariants = () => {
       id: string;
       size?: string;
       format?: string;
+      silent?: boolean;
     }) => photos.regenerateVariants(id, { size, format }),
 
-    onError: () => {
+    onError: (_error, variables) => {
+      if (variables.silent) return;
       toast.error("Failed to regenerate variants. Please try again.");
     },
 
-    onSuccess: (updatedPhoto) => {
+    onSuccess: (updatedPhoto, variables) => {
       void queryClient.invalidateQueries({ queryKey: photoKeys.lists() });
       void queryClient.invalidateQueries({
         queryKey: photoKeys.detail(updatedPhoto.id),
@@ -581,6 +583,7 @@ export const useRegenerateVariants = () => {
 
       usePhotoCacheStore.getState().updatePhoto(updatedPhoto.id, updatedPhoto);
 
+      if (variables.silent) return;
       toast.success("Variants regenerated!");
     },
   });

--- a/frontend/src/pages/admin/AdminPhotos.tsx
+++ b/frontend/src/pages/admin/AdminPhotos.tsx
@@ -31,6 +31,7 @@ import {
   useReorderPhotos,
 } from "../../hooks/usePhotos";
 import type { Photo } from "../../types";
+import { formatFileSize } from "../../utils/photoUtils";
 import toast from "react-hot-toast";
 import { cn } from "../../lib/utils";
 import { useLocalState } from "../../hooks/useLocalState";
@@ -126,14 +127,6 @@ const AdminPhotos: React.FC = () => {
         console.error(`Failed to update photo ${photoId}:`, error);
       }
     }
-  };
-
-  const formatFileSize = (bytes: number) => {
-    if (bytes === 0) return "0 B";
-    const k = 1024;
-    const sizes = ["B", "KB", "MB", "GB"];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
   };
 
   const buildOrderPayload = (orderedPhotos: Photo[]) =>

--- a/frontend/src/pages/admin/AdminPhotos.tsx
+++ b/frontend/src/pages/admin/AdminPhotos.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { AdminPageLayout } from "../../components/admin/AdminPageLayout";
 import { motion, AnimatePresence } from "framer-motion";
 import {
@@ -43,7 +44,8 @@ const AdminPhotos: React.FC = () => {
     "admin-photos-viewMode",
     "grid",
   );
-  const [editingPhoto, setEditingPhoto] = useState<Photo | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const editingPhotoId = searchParams.get("photo");
   const [reorderEnabled, setReorderEnabled] = useState(false);
   const [showStats, setShowStats] = useState(false);
 
@@ -68,10 +70,27 @@ const AdminPhotos: React.FC = () => {
     total_size: 0,
   };
 
-  // Keep the editor in sync with refetched photo data (e.g. after variant regeneration)
-  const currentEditingPhoto = editingPhoto
-    ? (photos.find((p) => p.id === editingPhoto.id) ?? editingPhoto)
+  // Driven by the ?photo= URL param so the editor survives a page refresh
+  const currentEditingPhoto = editingPhotoId
+    ? (photos.find((p) => p.id === editingPhotoId) ?? null)
     : null;
+  const isResolvingEditingPhoto =
+    !!editingPhotoId && !currentEditingPhoto && isLoadingPhotos;
+
+  const setEditingPhoto = (photo: Photo | null) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (photo) {
+          next.set("photo", photo.id);
+        } else {
+          next.delete("photo");
+        }
+        return next;
+      },
+      { replace: !photo },
+    );
+  };
 
   const handleUploadComplete = () => {
     setShowUpload(false);
@@ -446,7 +465,11 @@ const AdminPhotos: React.FC = () => {
           )}
         </div>
 
-        {viewMode === "grid" ? (
+        {isResolvingEditingPhoto ? (
+          <div className="min-h-[600px] flex items-center justify-center text-muted-foreground">
+            Loading photo...
+          </div>
+        ) : viewMode === "grid" ? (
           currentEditingPhoto ? (
             <PhotoForm
               photo={currentEditingPhoto}

--- a/frontend/src/pages/admin/AdminPhotos.tsx
+++ b/frontend/src/pages/admin/AdminPhotos.tsx
@@ -68,6 +68,11 @@ const AdminPhotos: React.FC = () => {
     total_size: 0,
   };
 
+  // Keep the editor in sync with refetched photo data (e.g. after variant regeneration)
+  const currentEditingPhoto = editingPhoto
+    ? (photos.find((p) => p.id === editingPhoto.id) ?? editingPhoto)
+    : null;
+
   const handleUploadComplete = () => {
     setShowUpload(false);
   };
@@ -432,7 +437,7 @@ const AdminPhotos: React.FC = () => {
             All Photos ({photos.length})
           </h2>
 
-          {photos.length > 0 && !editingPhoto && (
+          {photos.length > 0 && !currentEditingPhoto && (
             <Button variant="ghost" size="sm" onClick={() => handleSelectAll()}>
               {selectedPhotos.size === photos.length
                 ? "Deselect All"
@@ -442,9 +447,9 @@ const AdminPhotos: React.FC = () => {
         </div>
 
         {viewMode === "grid" ? (
-          editingPhoto ? (
+          currentEditingPhoto ? (
             <PhotoForm
-              photo={editingPhoto}
+              photo={currentEditingPhoto}
               onCancel={() => setEditingPhoto(null)}
               onSuccess={() => setEditingPhoto(null)}
               onDelete={(photo) => {
@@ -492,9 +497,9 @@ const AdminPhotos: React.FC = () => {
               />
             </div>
           )
-        ) : editingPhoto ? (
+        ) : currentEditingPhoto ? (
           <PhotoForm
-            photo={editingPhoto}
+            photo={currentEditingPhoto}
             onCancel={() => setEditingPhoto(null)}
             onSuccess={() => setEditingPhoto(null)}
             onDelete={(photo) => {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,3 +1,23 @@
+export interface ImageVariant {
+  path: string;
+  filename: string;
+  width: number;
+  height: number;
+  size_bytes: number;
+  format: string;
+  url?: string; // Secure API URL for accessing the variant
+}
+
+export interface MultiFormatVariants {
+  avif?: ImageVariant;
+  webp?: ImageVariant;
+  jpeg?: ImageVariant;
+  // Convenience fields surfaced by populate_photo_urls
+  width?: number;
+  height?: number;
+  url?: string;
+}
+
 export interface Photo {
   id: string;
   title: string;
@@ -13,18 +33,12 @@ export interface Photo {
   webp_path?: string;
 
   // Responsive image variants
-  variants?: Record<
-    string,
-    {
-      path: string;
-      filename: string;
-      width: number;
-      height: number;
-      size_bytes: number;
-      format: string;
-      url?: string; // Secure API URL for accessing the variant
-    }
-  >;
+  // Each size maps to either a legacy flat variant or a nested multi-format
+  // object (avif/webp/jpeg), each carrying their own size_bytes/url/etc.
+  variants?: Record<string, ImageVariant | MultiFormatVariants>;
+
+  // Non-persistent warnings about missing/failed variant formats
+  processing_errors?: string[];
 
   // EXIF data
   location_lat?: number;

--- a/frontend/src/utils/imageSelectionDebug.ts
+++ b/frontend/src/utils/imageSelectionDebug.ts
@@ -7,7 +7,7 @@ import {
   debugImageSelection,
   ImageUseCase,
 } from "./imageUtils";
-import type { Photo } from "../types";
+import type { MultiFormatVariants, Photo } from "../types";
 
 // Mock photo for testing
 const testPhoto: Photo = {
@@ -26,52 +26,89 @@ const testPhoto: Photo = {
   updated_at: "2024-01-01T00:00:00Z",
   variants: {
     thumbnail: {
-      path: "/compressed/debug-thumbnail.webp",
-      filename: "debug-thumbnail.webp",
-      url: "/api/photos/debug-photo/file/thumbnail",
+      webp: {
+        path: "/compressed/debug-thumbnail.webp",
+        filename: "debug-thumbnail.webp",
+        url: "/api/photos/debug-photo/file/thumbnail",
+        width: 400,
+        height: 300,
+        size_bytes: 25000,
+        format: "webp",
+      },
       width: 400,
       height: 300,
-      size_bytes: 25000,
-      format: "webp",
+      url: "/api/photos/debug-photo/file/thumbnail",
     },
     small: {
-      path: "/compressed/debug-small.webp",
-      filename: "debug-small.webp",
-      url: "/api/photos/debug-photo/file/small",
+      webp: {
+        path: "/compressed/debug-small.webp",
+        filename: "debug-small.webp",
+        url: "/api/photos/debug-photo/file/small",
+        width: 800,
+        height: 600,
+        size_bytes: 75000,
+        format: "webp",
+      },
       width: 800,
       height: 600,
-      size_bytes: 75000,
-      format: "webp",
+      url: "/api/photos/debug-photo/file/small",
     },
     medium: {
-      path: "/compressed/debug-medium.webp",
-      filename: "debug-medium.webp",
-      url: "/api/photos/debug-photo/file/medium",
+      webp: {
+        path: "/compressed/debug-medium.webp",
+        filename: "debug-medium.webp",
+        url: "/api/photos/debug-photo/file/medium",
+        width: 1200,
+        height: 900,
+        size_bytes: 150000,
+        format: "webp",
+      },
       width: 1200,
       height: 900,
-      size_bytes: 150000,
-      format: "webp",
+      url: "/api/photos/debug-photo/file/medium",
     },
     large: {
-      path: "/compressed/debug-large.webp",
-      filename: "debug-large.webp",
-      url: "/api/photos/debug-photo/file/large",
+      webp: {
+        path: "/compressed/debug-large.webp",
+        filename: "debug-large.webp",
+        url: "/api/photos/debug-photo/file/large",
+        width: 1600,
+        height: 1200,
+        size_bytes: 250000,
+        format: "webp",
+      },
       width: 1600,
       height: 1200,
-      size_bytes: 250000,
-      format: "webp",
+      url: "/api/photos/debug-photo/file/large",
     },
     xlarge: {
-      path: "/compressed/debug-xlarge.webp",
-      filename: "debug-xlarge.webp",
-      url: "/api/photos/debug-photo/file/xlarge",
+      webp: {
+        path: "/compressed/debug-xlarge.webp",
+        filename: "debug-xlarge.webp",
+        url: "/api/photos/debug-photo/file/xlarge",
+        width: 2400,
+        height: 1800,
+        size_bytes: 450000,
+        format: "webp",
+      },
       width: 2400,
       height: 1800,
-      size_bytes: 450000,
-      format: "webp",
+      url: "/api/photos/debug-photo/file/xlarge",
     },
   },
 };
+
+/**
+ * Get the size in bytes of a variant, checking avif/webp/jpeg in precedence order
+ * (matching the backend's populate_photo_urls precedence).
+ */
+const getVariantSizeBytes = (
+  variant: MultiFormatVariants | undefined,
+): number =>
+  variant?.avif?.size_bytes ??
+  variant?.webp?.size_bytes ??
+  variant?.jpeg?.size_bytes ??
+  0;
 
 interface DeviceTest {
   name: string;
@@ -206,7 +243,7 @@ export const testImageSelectionAcrossDevices = () => {
         targetSize: debug.targetSize,
         actualSize:
           testPhoto.variants?.[selection.selectedVariant]?.width ?? "N/A",
-        fileSize: `${Math.round((testPhoto.variants?.[selection.selectedVariant]?.size_bytes ?? 0) / 1024)}KB`,
+        fileSize: `${Math.round(getVariantSizeBytes(testPhoto.variants?.[selection.selectedVariant]) / 1024)}KB`,
         url: selection.url,
       });
 
@@ -218,7 +255,9 @@ export const testImageSelectionAcrossDevices = () => {
         selectedVariant: selection.selectedVariant,
         targetSize: debug.targetSize,
         actualSize: testPhoto.variants?.[selection.selectedVariant]?.width,
-        fileSize: testPhoto.variants?.[selection.selectedVariant]?.size_bytes,
+        fileSize: getVariantSizeBytes(
+          testPhoto.variants?.[selection.selectedVariant],
+        ),
       });
     });
 
@@ -259,11 +298,14 @@ export const testBandwidthEfficiency = () => {
 
     Object.values(ImageUseCase).forEach((useCase) => {
       const staticVariant = staticSelection[useCase];
-      const staticBytes = testPhoto.variants?.[staticVariant]?.size_bytes ?? 0;
+      const staticBytes = getVariantSizeBytes(
+        testPhoto.variants?.[staticVariant],
+      );
 
       const dynamicSelection = selectOptimalImage(testPhoto, useCase);
-      const dynamicBytes =
-        testPhoto.variants?.[dynamicSelection.selectedVariant]?.size_bytes ?? 0;
+      const dynamicBytes = getVariantSizeBytes(
+        testPhoto.variants?.[dynamicSelection.selectedVariant],
+      );
 
       totalStaticBytes += staticBytes;
       totalDynamicBytes += dynamicBytes;

--- a/frontend/src/utils/imageSelectionDebug.ts
+++ b/frontend/src/utils/imageSelectionDebug.ts
@@ -5,6 +5,8 @@
 import {
   selectOptimalImage,
   debugImageSelection,
+  getVariantWidth,
+  getVariantHeight,
   ImageUseCase,
 } from "./imageUtils";
 import type { MultiFormatVariants, Photo } from "../types";
@@ -371,7 +373,9 @@ export const testHighDPIQuality = () => {
       const variant = testPhoto.variants?.[selection.selectedVariant];
 
       if (variant) {
-        const pixelDensity = variant.width / device.viewportWidth;
+        const variantWidth = getVariantWidth(variant);
+        const variantHeight = getVariantHeight(variant);
+        const pixelDensity = variantWidth / device.viewportWidth;
         const qualityScore = Math.min(
           pixelDensity * device.devicePixelRatio,
           3,
@@ -380,7 +384,7 @@ export const testHighDPIQuality = () => {
         // eslint-disable-next-line no-console
         console.log(`${useCase}:`, {
           variant: selection.selectedVariant,
-          resolution: `${variant.width}×${variant.height}`,
+          resolution: `${variantWidth}×${variantHeight}`,
           pixelDensity: `${pixelDensity.toFixed(2)}x`,
           qualityScore: `${qualityScore.toFixed(2)}/3`,
           sharpness:

--- a/frontend/src/utils/imageUtils.ts
+++ b/frontend/src/utils/imageUtils.ts
@@ -2,11 +2,21 @@
  * Image optimization utilities for DPI-aware and responsive image selection
  */
 
+import type {
+  ImageVariant as PhotoImageVariant,
+  MultiFormatVariants,
+} from "../types";
+
+// A size entry in a Photo's variants map: either the legacy flat shape
+// (ImageVariant) or the nested multi-format shape (MultiFormatVariants).
+export type VariantEntry = PhotoImageVariant | MultiFormatVariants;
+export type VariantsMap = Record<string, VariantEntry>;
+
 // Accept photo-like objects rather than a strict Photo type
 export type PhotoLike = {
   filename: string;
   original_url?: string;
-  variants?: Record<string, ImageVariant>;
+  variants?: VariantsMap;
 };
 
 export interface DeviceContext {
@@ -16,16 +26,60 @@ export interface DeviceContext {
   connectionSpeed?: "slow" | "fast" | "unknown";
 }
 
-export interface ImageVariant {
-  // Fields are optional except width; callers/tests may not provide everything
-  path?: string;
-  filename?: string;
-  url?: string;
-  width: number;
-  height?: number;
-  size_bytes?: number;
-  format?: string;
-}
+/**
+ * Type guard narrowing a variant entry to its nested multi-format shape,
+ * i.e. one that may carry avif/webp/jpeg sub-objects.
+ */
+const isMultiFormatVariant = (
+  variant: VariantEntry,
+): variant is MultiFormatVariants =>
+  "avif" in variant || "webp" in variant || "jpeg" in variant;
+
+/**
+ * Resolves the pixel width of a variant entry, checking the size-level
+ * field first and falling back to avif/webp/jpeg in precedence order
+ * (matching the backend's populate_photo_urls precedence).
+ */
+export const getVariantWidth = (variant: VariantEntry | undefined): number => {
+  if (!variant) return 0;
+  if (variant.width !== undefined) return variant.width;
+  if (isMultiFormatVariant(variant)) {
+    return (
+      variant.avif?.width ?? variant.webp?.width ?? variant.jpeg?.width ?? 0
+    );
+  }
+  return 0;
+};
+
+/**
+ * Resolves the pixel height of a variant entry, checking the size-level
+ * field first and falling back to avif/webp/jpeg in precedence order.
+ */
+export const getVariantHeight = (variant: VariantEntry | undefined): number => {
+  if (!variant) return 0;
+  if (variant.height !== undefined) return variant.height;
+  if (isMultiFormatVariant(variant)) {
+    return (
+      variant.avif?.height ?? variant.webp?.height ?? variant.jpeg?.height ?? 0
+    );
+  }
+  return 0;
+};
+
+/**
+ * Resolves the URL of a variant entry, checking the size-level field first
+ * and falling back to avif/webp/jpeg in precedence order.
+ */
+export const getVariantUrl = (
+  variant: VariantEntry | undefined,
+): string | undefined => {
+  if (!variant) return undefined;
+  if (variant.url !== undefined) return variant.url;
+  if (isMultiFormatVariant(variant)) {
+    return variant.avif?.url ?? variant.webp?.url ?? variant.jpeg?.url;
+  }
+  return undefined;
+};
 
 export interface OptimalImageSelection {
   selectedVariant: string;
@@ -196,7 +250,7 @@ export const calculateTargetSize = (
  */
 export const selectPlaceholderVariant = (
   useCase: ImageUseCase,
-  variants: Record<string, ImageVariant>,
+  variants: VariantsMap,
 ): { variant: string; url: string } => {
   // For large images, we want a slightly higher res placeholder (e.g. tablet size)
   // For small images, a tiny thumbnail is enough.
@@ -205,23 +259,25 @@ export const selectPlaceholderVariant = (
 
   if (isLarge) {
     // Try medium or small for a reasonably sharp initial impression on hero sections
-    if (variants.medium?.url)
-      return { variant: "medium", url: variants.medium.url };
-    if (variants.small?.url)
-      return { variant: "small", url: variants.small.url };
+    const mediumUrl = getVariantUrl(variants.medium);
+    if (mediumUrl) return { variant: "medium", url: mediumUrl };
+    const smallUrl = getVariantUrl(variants.small);
+    if (smallUrl) return { variant: "small", url: smallUrl };
   } else {
     // Try micro or thumbnail for general grid items
-    if (variants.micro?.url)
-      return { variant: "micro", url: variants.micro.url };
-    if (variants.thumbnail?.url)
-      return { variant: "thumbnail", url: variants.thumbnail.url };
+    const microUrl = getVariantUrl(variants.micro);
+    if (microUrl) return { variant: "micro", url: microUrl };
+    const thumbnailUrl = getVariantUrl(variants.thumbnail);
+    if (thumbnailUrl) return { variant: "thumbnail", url: thumbnailUrl };
   }
 
   // Fallback to whatever is available
   const entries = Object.entries(variants);
   if (entries.length > 0) {
-    const smallest = entries.sort(([, a], [, b]) => a.width - b.width)[0];
-    return { variant: smallest[0], url: smallest[1].url ?? "" };
+    const smallest = entries.sort(
+      ([, a], [, b]) => getVariantWidth(a) - getVariantWidth(b),
+    )[0];
+    return { variant: smallest[0], url: getVariantUrl(smallest[1]) ?? "" };
   }
 
   return { variant: "original", url: "" };
@@ -231,7 +287,7 @@ export const selectPlaceholderVariant = (
  * Finds the best variant for a given target size
  */
 export const findOptimalVariant = (
-  variants: Record<string, ImageVariant>,
+  variants: VariantsMap,
   targetSize: number,
   connectionSpeed: "slow" | "fast" | "unknown" = "unknown",
 ): string => {
@@ -243,7 +299,7 @@ export const findOptimalVariant = (
 
   // Sort variants by width
   const sortedVariants = variantEntries.sort(
-    ([, a], [, b]) => a.width - b.width,
+    ([, a], [, b]) => getVariantWidth(a) - getVariantWidth(b),
   );
 
   // For slow connections, prefer smaller images
@@ -255,7 +311,7 @@ export const findOptimalVariant = (
   let bestVariant = sortedVariants[0][0]; // Start with smallest
 
   for (const [variantName, variant] of sortedVariants) {
-    if (variant.width >= targetSize) {
+    if (getVariantWidth(variant) >= targetSize) {
       bestVariant = variantName;
       break;
     }
@@ -269,14 +325,14 @@ export const findOptimalVariant = (
 /**
  * Generates srcset string for responsive images
  */
-export const generateSrcSet = (
-  variants: Record<string, ImageVariant>,
-): string => {
+export const generateSrcSet = (variants: VariantsMap): string => {
   const variantEntries = Object.entries(variants);
 
   return variantEntries
-    .filter(([, variant]) => variant.url) // Only include variants with URLs
-    .map(([, variant]) => `${variant.url} ${variant.width}w`)
+    .filter(([, variant]) => getVariantUrl(variant)) // Only include variants with URLs
+    .map(
+      ([, variant]) => `${getVariantUrl(variant)} ${getVariantWidth(variant)}w`,
+    )
     .join(", ");
 };
 
@@ -324,9 +380,12 @@ export const selectOptimalImage = (
 
   // Get URLs with proper fallbacks
   const selectedUrl =
-    variants[selectedVariant]?.url ?? photo.original_url ?? "";
+    getVariantUrl(variants[selectedVariant]) ?? photo.original_url ?? "";
   const fallbackUrl =
-    variants.small?.url ?? variants.thumbnail?.url ?? photo.original_url ?? "";
+    getVariantUrl(variants.small) ??
+    getVariantUrl(variants.thumbnail) ??
+    photo.original_url ??
+    "";
 
   // Generate responsive attributes
   const srcset =

--- a/frontend/src/utils/photoUtils.ts
+++ b/frontend/src/utils/photoUtils.ts
@@ -5,6 +5,17 @@ import type { OrderByOption } from "../components/OrderBySelector";
  * Photo utility functions for cache optimization and intersection analysis
  */
 
+/**
+ * Formats a byte count into a human-readable string (e.g. "1.5 MB").
+ */
+export const formatFileSize = (bytes: number): string => {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
+};
+
 export interface PhotoIntersectionResult {
   intersection: Photo[];
   onlyInA: Photo[];


### PR DESCRIPTION
## Summary

Photo grid and map thumbnails were taking several seconds to load with only a couple of photos, because every responsive variant except `micro` was failing to generate and the frontend was silently falling back to serving the multi-MB original JPEGs.

### Root cause
`vips_processor.py` loaded the source image with `access="sequential"` and then called `.resize()` on the same image object once per target size (micro/thumbnail/small/medium/large/xlarge). A sequential-access vips pipeline can only be read once — after the first resize+save (micro), every subsequent resize from the same source silently failed, leaving `thumbnail`/`small`/`medium`/`large`/`xlarge` as empty `{}` in the `variants` JSON for every upload.

### Fixes
- **`backend/app/core/vips_processor.py`**: load the source with `access="random"` so all six sizes can be independently re-derived from one in-memory decode. Existing per-format try/except-and-continue behavior (so an AVIF failure doesn't block webp/jpeg) is preserved.
- **AVIF/HEIF encoding**: was structurally broken because Debian's `libheif` ships with zero AVIF/HEVC *encoder* plugins (only decoder plugins for dav1d/libde265 exist). `docker/Dockerfile` and `docker/Dockerfile.dev` now build libheif's AOM/x265 encoder plugins from source, pinned to the installed `libheif-dev` version, restoring AVIF variant generation.

### New: admin variant regeneration UI
- New endpoint `POST /api/photos/{id}/regenerate-variants` (admin-only, optional `size`/`format` filters) re-runs variant generation against a photo's stored original and merges results into `variants`.
- New `PhotoVariantsTable` component in the admin photo editor (left panel, below equipment selection) shows a size x format grid with checkmarks and compressed sizes vs the original file size, missing/errored cells highlighted, and a hover-to-regenerate action per cell with immediate refresh.
- Frontend cache wiring (`useRegenerateVariants`, plus `useUpdatePhoto`/`useTogglePhotoFeatured`/`useDeletePhoto`) now syncs the persisted Zustand `photoCache` store used by `PhotographyPage`, so admin edits and regenerations show up immediately instead of waiting out the 5-minute cache TTL.

Full investigation notes and follow-ups in `docs/IMAGE_VARIANT_BUG.md`.

## Test plan
- [x] `ruff check` / `ruff format` / `mypy` clean on changed backend files
- [x] `eslint` / `prettier` / `tsc --noEmit` clean on changed frontend files
- [x] `pre-commit run` passes on all changed files
- [x] Manual: upload a new photo, confirm all variant sizes generate (webp/jpeg, and avif once the Dockerfile rebuild lands)
- [x] Manual: open an existing photo with missing variants in admin, use the variants table to regenerate a missing cell, confirm it updates immediately
- [x] Manual: edit a photo's location in admin, confirm it reflects on the Photography page without waiting for cache expiry